### PR TITLE
Add status label resolution rules

### DIFF
--- a/agents/tl-analyst.md
+++ b/agents/tl-analyst.md
@@ -53,6 +53,7 @@ If estimated cost > 200 credits, ask the user to confirm before proceeding.
 
 ## Rules
 
+- **Always resolve numeric codes to human-readable labels** in your output. Never show "Status 3" — show "Sold". Status mapping: 0=Proposed, 1=Unavailable, 2=Pending, 3=Sold, 4=Rejected by Advertiser, 5=Rejected by Publisher, 6=Proposal Approved, 7=Matched, 8=Reached Out, 9=Rejected by Agency.
 - Always use `--json` for output you need to parse
 - Always include `--limit` on list queries to control credit spend
 - For `tl snapshots video`, always include `--channel` (required for Firebolt performance)

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -120,6 +120,10 @@ Users only see data their plan allows:
 - **Intelligence plan** required for `tl brands`, full `tl channels list` search, and full `tl uploads list`.
 - **Paid plan** required for `tl snapshots`.
 
+## Important: Status Labels
+
+When presenting sponsorship status data, always use human-readable labels — never raw codes. The `tl` CLI returns lowercase labels (`sold`, `pending`, `matched`, etc.) — capitalize them for display. Full mapping: proposed, unavailable, pending, sold, advertiser_reject → "Rejected by Advertiser", publisher_reject → "Rejected by Publisher", proposal_approved → "Proposal Approved", matched, outreach → "Reached Out", agency_reject → "Rejected by Agency".
+
 ## Important: Firebolt Snapshots
 
 `tl snapshots video` **always requires** `--channel`. Without it, the query scans 7.4 billion rows and times out. Always provide the channel ID.


### PR DESCRIPTION
## Summary
- Agents were showing raw numeric `publish_status` codes ("Status 3") instead of human-readable labels ("Sold") in data summaries
- Added explicit status mapping rule to `tl-analyst` agent and `tl` skill
- Full mapping: 0=Proposed, 2=Pending, 3=Sold, 4=Rejected by Advertiser, etc.

## Test plan
- [ ] Run a `tl` data query that groups by status — verify labels appear instead of numeric codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)