### PR TITLE
Add channel demographic and geo filters to sponsorship finder

### DIFF
--- a/commands/tl-channels.md
+++ b/commands/tl-channels.md
@@ -15,3 +15,6 @@ Examples:
 - "/tl-channels cooking channels over 100k" → `tl channels list category:cooking min-subs:100000`
 - "/tl-channels 12345" → `tl channels show 12345`
 - "/tl-channels English gaming channels" → `tl channels list category:gaming language:en`
+- "/tl-channels mobile-first channels" → `tl channels list primary-device:mobile`
+- "/tl-channels channels with majority US audience" → `tl channels list min-us-share:50`
+- "/tl-channels mobile tech channels with US focus" → `tl channels list category:tech primary-device:mobile min-us-share:60`

--- a/commands/tl-sponsorships.md
+++ b/commands/tl-sponsorships.md
@@ -16,4 +16,6 @@ If no specific request is given, run `tl sponsorships list --limit 10` to show r
 Examples:
 - "/tl-sponsorships pending with send dates in April" → `tl sponsorships list status:pending send-date:2026-04`
 - "/tl-sponsorships Nike" → `tl sponsorships list brand:"Nike"`
+- "/tl-sponsorships sold deals on mobile-first channels" → `tl sponsorships list status:sold primary-device:mobile`
+- "/tl-sponsorships deals on channels with majority US audience" → `tl sponsorships list min-us-share:50`
 - "/tl-sponsorships 12345" → `tl sponsorships show 12345`

--- a/commands/tl.md
+++ b/commands/tl.md
@@ -19,6 +19,7 @@ The user wants to query ThoughtLeaders data. Translate their request into the ri
 
 - "/tl sold sponsorships for Nike in Q1" → `tl sponsorships list status:sold brand:"Nike" since:2026-01-01 until:2026-03-31`
 - "/tl cooking channels over 100k subs" → `tl channels list category:cooking min-subs:100000`
+- "/tl mobile-first US cooking channels" → `tl channels list category:cooking primary-device:mobile min-us-share:50`
 - "/tl Nike's sponsorship activity" → `tl brands show Nike`
 - "/tl run my Q1 report" → `tl reports --json` then `tl reports run <id>`
 - "/tl check my balance" → `tl balance`

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -103,6 +103,30 @@ tl channels list category:cooking min-subs:100k language:en
 
 Date filters accept keywords: `today`, `yesterday`, `tomorrow`.
 
+#### Channel demographic filters
+
+These filters apply to both `tl channels list` and `tl sponsorships list` (the latter filters by the associated channel's demographics):
+
+```bash
+# Primary device type
+tl channels list primary-device:mobile
+tl channels list primary-device:desktop
+tl channels list primary-device:tablet
+
+# Minimum device audience share (0–100)
+tl channels list min-mobile-share:60
+tl channels list min-desktop-share:30
+tl channels list min-tablet-share:10
+
+# Minimum geo share (0–100, ISO country codes lowercase)
+tl channels list min-us-share:70
+tl channels list min-gb-share:25
+
+# Combine with other filters
+tl channels list category:tech primary-device:mobile min-us-share:50 min-subs:100k
+tl sponsorships list status:sold primary-device:mobile min-us-share:60
+```
+
 ### Output flags
 - `--json` — structured JSON (use this for parsing)
 - `--csv` — CSV output
@@ -156,4 +180,14 @@ tl snapshots video def789 --channel 456 --json
 ```bash
 tl reports --json  # Find the report ID first
 tl reports run 42 --json
+```
+
+"Find mobile-first US channels in cooking":
+```bash
+tl channels list category:cooking primary-device:mobile min-us-share:50 --json
+```
+
+"Show sold sponsorships targeting mobile US audiences":
+```bash
+tl sponsorships list status:sold primary-device:mobile min-us-share:60 --json
 ```


### PR DESCRIPTION
Documents new channel-level filter keys — primary-device, min-{device}-share,
and min-{country}-share — in the skill and slash-command docs. These filters
apply to both tl channels list and tl sponsorships list (the latter queries
sponsorships by the demographics of their associated channel). No Python code
changes needed; the generic filter system already passes arbitrary key:value
pairs to the API.

https://claude.ai/code/session_019ES6QwTuoC9qixQpczgAtu