### PR TITLE
Scaffold tl-report-build skill (Milestone 1)

### DIFF
--- a/skills/tl-report-build/SKILL.md
+++ b/skills/tl-report-build/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: tl-report-build
+description: Build a saved ThoughtLeaders report from a natural-language request. Triggers when the user asks to build, create, design, configure, or save a report; or when `tl ask` receives a report-building request. Orchestrates topic matching, filter construction, real-data validation, and column/widget selection — locally in the user's Claude session, against the existing `tl` CLI surface.
+---
+
+# ThoughtLeaders Report Builder (v2 prototype)
+
+> **Status: Milestone 1 — scaffolding.** The phases below are described but not yet implemented. When triggered, this skill currently emits a stub response that names each phase it would run. Subsequent milestones fill in the prompts and orchestration.
+
+## What this skill does
+
+Given a natural-language request like *"build me a report about gaming channels in the US"*, this skill produces a complete report configuration (filters + columns + widgets) compatible with `tl reports create`. The user reviews the configuration and chooses whether to save.
+
+This is the **client-side** report builder. Claude orchestrates the flow on the user's machine; the platform's role is reduced to data APIs (which `tl` already calls).
+
+## When to trigger
+
+Trigger on any of:
+
+- The user asks to **build, create, design, configure, or save a report**
+- The user says something like *"can you make me a dashboard for X"*, *"set up tracking for Y"*, *"I want to monitor Z"*
+- `tl ask "<query>"` is invoked and the query reads as a report-building request rather than a one-shot data lookup
+
+Do **not** trigger for one-shot data questions ("how many sold deals last week?") — those route to the `tl` data-analyst skill, which composes structured queries directly.
+
+If the request is ambiguous between "answer this question" and "save a report that answers this question", ask the user which they want before running this skill.
+
+## The flow (five phases)
+
+This skill executes a sync state machine. Each phase has a clear input, output, and validation gate. Stop and ask the user if any phase produces a result you cannot defend.
+
+### Phase 1 — Report Type Selection
+
+**Input**: the user's NL request.
+
+**Action**: classify the request into a report type (e.g. `CONTENT`, `BRANDS`, `THOUGHTLEADERS`, `CHANNELS`). Use the schema returned by `tl describe show reports` to confirm the available types.
+
+**Output**: a single report-type label.
+
+### Phase 2 — Filter Selection (LLM Pass A)
+
+**Input**: NL request + selected report type.
+
+**Action**:
+1. **Topic match.** Read `data/topics_v1.json` (bundled snapshot of the seeded topic cache). Run `prompts/topic_matcher.md` to score each topic in the snapshot as `strong` / `weak` / `none`, with reasoning + matching keywords.
+2. **Keyword research.** If no topic is `strong`, generate candidate keyword sets and validate each via `tl channels keyword:"<kw>" --json` or `tl uploads search:"<kw>" --json` to confirm the keyword returns non-zero results.
+3. **Filter build.** Run `prompts/filter_builder.md` to translate matched topics + keywords + other request hints (date range, demographics, geo) into a partial FilterSet (filters only — no columns/widgets yet). Use `tl describe show <resource> --json` to discover the legal filter keys for the report type.
+
+**Output**: a partial FilterSet (JSON) — filters only.
+
+### Phase 3 — Validation Loop
+
+**Input**: the partial FilterSet from Phase 2.
+
+**Action**: translate the filters into the equivalent `tl` invocation and check real data:
+
+| Report type focus | Validation command |
+|---|---|
+| Channel-side filters | `tl channels <filters> --json --limit 10` |
+| Sponsorship-side filters | `tl sponsorships <filters> --json --limit 10` |
+| Upload-side filters | `tl uploads <filters> --json --limit 10` |
+| Brand-side filters | `tl brands <filters> --json --limit 10` |
+
+Read `total` from the response envelope and the first 10 rows.
+
+**Decision rules**:
+- `total == 0` → loop back to Phase 2 with feedback ("filters too narrow; here is what was tried"). Cap at **3 retries**.
+- `total` is reasonable for the request (judged by Claude in context, not a hard threshold) → proceed to Phase 4.
+- `total` is enormous (e.g. millions of rows for a request that implies a small cohort) → loop back to Phase 2 to narrow.
+
+This loop is **mandatory**, not optional. A FilterSet that has not been validated against real data must not advance.
+
+**Output**: a validated FilterSet + a sample of rows (kept in working memory for Phase 4 context).
+
+### Phase 4 — Column / Widget Selection (LLM Pass B)
+
+**Input**: validated FilterSet + report type + sample rows.
+
+**Action**: run `prompts/column_widget_builder.md` to pick the columns and widgets that best surface the answer the user asked for. Consult `data/sortable_columns.json` for column metadata (sortability, default direction, display name) and `tl describe show <resource> --json` for the full available column set.
+
+This is a **separate LLM call** from Phase 2. Do not bundle filter selection and column/widget selection into one prompt — the model optimizes both worse when they are combined.
+
+**Output**: a complete report configuration (filters + columns + widgets) as JSON.
+
+### Phase 5 — Save (or display)
+
+**Action during prototype**: display the complete configuration JSON for human review. Suggest the user run `tl reports create "<their original request>"` if they want to commit it. Do **not** auto-save during the prototype phase.
+
+**Future**: once the skill is trusted via the offline refinement pipeline, this phase calls `tl reports create` directly with the constructed config.
+
+## Tools the skill uses
+
+The skill has **no Python and no new `tl` subcommands**. Every "tool" is a prompt or a composition of existing CLI calls:
+
+| Tool | Implementation |
+|---|---|
+| Topic Matcher | `prompts/topic_matcher.md` reading `data/topics_v1.json` |
+| Keyword Researcher | Reasoning over candidate keywords + validation via `tl channels keyword:"<kw>"` / `tl uploads search:"<kw>"` |
+| Schema discovery | `tl describe show <resource> --json` |
+| Validation (count + sample) | `tl channels` / `tl uploads` / `tl sponsorships` / `tl brands` with the candidate filters |
+| Filter Builder (Pass A) | `prompts/filter_builder.md` |
+| Column / Widget Builder (Pass B) | `prompts/column_widget_builder.md` + `data/sortable_columns.json` |
+| Save | `tl reports create` (manual during prototype) |
+
+If a real gap surfaces during prototyping (e.g. composing four entity queries to estimate a count gets unwieldy), that's a signal to add a new `tl` subcommand — but only at promotion time, not preemptively.
+
+## Working files
+
+```
+skills/tl-report-build/
+├── SKILL.md                            ← this file
+├── prompts/
+│   ├── topic_matcher.md                ← (Milestone 2)
+│   ├── filter_builder.md               ← (Milestone 3)
+│   └── column_widget_builder.md        ← (Milestone 5)
+├── data/
+│   ├── topics_v1.json                  ← topic cache snapshot (synced from prod)
+│   └── sortable_columns.json           ← column metadata
+└── examples/
+    └── golden_queries.md               ← hand-curated test cases
+```
+
+## Stub behaviour during Milestone 1
+
+Until the prompts in `prompts/` are written, when this skill is triggered:
+
+1. Acknowledge the user's request.
+2. List the five phases above as a checklist, marking each `[ ] not yet implemented`.
+3. Suggest the user falls back to the legacy `tl ask` server-side path or the existing `tl reports create` flow.
+4. Do not produce a fabricated FilterSet.
+
+## Refinement (offline)
+
+The skill itself is improved via a separate Creator/Judge/Coder loop run on goldens (`examples/golden_queries.md`) and real-user query corpora. That loop does **not** run when the skill is triggered by an end user — it's a dev-time tool. See the project architecture document for details.
+
+## Constraints
+
+- **CLI-only.** This skill never calls platform APIs directly. Everything goes through `tl`.
+- **No new `tl` subcommands during the prototype.** Compose what exists.
+- **No auto-save** during the prototype. Always display the config and let the user commit explicitly.
+- **Validation loop is mandatory.** A FilterSet that has not been checked against real data with a real count must not advance to Phase 4.
+- **Two LLM passes are mandatory.** Filter selection and column/widget selection are separate calls.

--- a/skills/tl-report-build/data/sortable_columns.json
+++ b/skills/tl-report-build/data/sortable_columns.json
@@ -1,0 +1,23 @@
+{
+  "_placeholder": true,
+  "_status": "Milestone 1 — placeholder. Awaiting initial sync.",
+  "_schema_version": "v1",
+  "_synced_from": "create-report skill's data/sortable_columns.json (platform repo)",
+  "_sync_instructions": [
+    "1. From the platform repo, copy .claude/skills/create-report/data/sortable_columns.json into this file.",
+    "2. The Column / Widget Builder (prompts/column_widget_builder.md, Milestone 5) reads this file to know which columns are sortable, default sort direction, and display labels.",
+    "3. Re-sync whenever the platform's column metadata changes. Until a tl-side schema endpoint exposes this, the sync is manual.",
+    "4. The skill should fall back to `tl describe show <resource> --json` for any column not present in this file — don't hard-fail."
+  ],
+  "_expected_shape": {
+    "<resource>": {
+      "<column_key>": {
+        "label": "<human-readable label>",
+        "sortable": true,
+        "default_sort": "asc | desc",
+        "type": "string | number | date | enum"
+      }
+    }
+  },
+  "columns": {}
+}

--- a/skills/tl-report-build/data/topics_v1.json
+++ b/skills/tl-report-build/data/topics_v1.json
@@ -1,0 +1,32 @@
+{
+  "_placeholder": true,
+  "_status": "Milestone 1 — placeholder. Awaiting initial sync.",
+  "_schema_version": "v1",
+  "_synced_from": "evals/topics/seed_topics_v1.json (platform repo)",
+  "_sync_instructions": [
+    "1. From the platform repo, copy evals/topics/seed_topics_v1.json into this file.",
+    "2. The Topic Matcher (prompts/topic_matcher.md, Milestone 2) reads from this file directly — do not transform structure during sync.",
+    "3. Re-sync whenever the seeded topic cache changes. Until a tl topics CLI subcommand exists, this is a manual step.",
+    "4. The skill must continue to function with a stale snapshot; degradation is gradual (older topics still match), not catastrophic."
+  ],
+  "_expected_shape": {
+    "topics": [
+      {
+        "id": "<integer, matches DB id>",
+        "name": "<canonical topic name>",
+        "description": "<one-line summary>",
+        "keywords": {
+          "core_head": ["..."],
+          "sub_segment": ["..."],
+          "long_tail": ["..."]
+        },
+        "evidence": {
+          "brands": ["..."],
+          "channels": ["..."],
+          "iab_tier_2": "<IAB tier 2 label>"
+        }
+      }
+    ]
+  },
+  "topics": []
+}

--- a/skills/tl-report-build/examples/golden_queries.md
+++ b/skills/tl-report-build/examples/golden_queries.md
@@ -1,0 +1,386 @@
+# Golden Queries — Report Builder v2
+
+Hand-curated natural-language requests used to evaluate the skill end-to-end.
+Each entry captures the request as a user would say it, the report type the
+skill should infer, the topic(s) it should match, and what a "good" output
+looks like. Use these for manual sanity checks during Milestones 2–5 and as
+seed inputs to the offline Creator/Judge/Coder loop in Milestone 8.
+
+> **Status: Milestone 1.** Examples below are seeds, not yet exercised against
+> a working skill. As prompts come online, annotate each with actual results
+> and flag failures.
+
+## How to read an entry
+
+```
+### N. <one-line summary of the request>
+
+**User says**: "<verbatim NL request>"
+
+**Expected report type**: <CONTENT | BRANDS | THOUGHTLEADERS | ...>
+
+**Expected topic match(es)**: <topic name(s) from data/topics_v1.json>
+
+**Expected filter shape**: <bullet list of must-have filters>
+
+**Validation expectation**: <rough non-zero count band, or "should narrow"
+                            if the first attempt is too broad>
+
+**Notes**: <gotchas, ambiguities, or what the skill should ask about>
+```
+
+---
+
+## Channel-discovery requests
+
+### 1. Mid-size US gaming channels
+
+**User says**: "build me a report tracking US gaming channels with 100k–1M subs"
+
+**Expected report type**: CHANNELS
+
+**Expected topic match**: Gaming (strong)
+
+**Expected filter shape**:
+- `category:gaming` (or topic match → gaming keyword expansion)
+- `min-us-share:50`
+- `min-subs:100k`
+- `max-subs:1m`
+
+**Validation expectation**: hundreds to low thousands of channels.
+
+**Notes**: a `max-subs` filter may not exist as a CLI key — the skill should
+verify via `tl describe show channels` and fall back to post-filter if needed.
+
+---
+
+### 2. Mobile-first cooking channels in the UK
+
+**User says**: "I want to monitor UK cooking channels whose audience is mostly on mobile"
+
+**Expected report type**: CHANNELS
+
+**Expected topic match**: Food & Drink (strong)
+
+**Expected filter shape**:
+- topic / category alignment with cooking
+- `primary-device:mobile`
+- `min-gb-share:50`
+
+**Validation expectation**: tens to low hundreds.
+
+**Notes**: tests demographic filter handling.
+
+---
+
+### 3. Look-alike cohort
+
+**User says**: "set up a dashboard for channels similar to MrBeast"
+
+**Expected report type**: CHANNELS
+
+**Expected topic match**: none (request is identity-based, not topic-based)
+
+**Expected filter shape**:
+- skill should suggest `tl channels similar` as a more direct path,
+  *or* construct a saved report based on similar channels' shared traits
+  (subs band, category, demo profile)
+
+**Validation expectation**: ~10–50 channels.
+
+**Notes**: edge case — skill should ask the user whether they want a static
+list (look-alike snapshot) or a live filter.
+
+---
+
+## Sponsorship / deal pipeline requests
+
+### 4. Sold deals this quarter
+
+**User says**: "build me a report of all sold deals in Q2 2026"
+
+**Expected report type**: SPONSORSHIPS (or DEALS)
+
+**Expected topic match**: none
+
+**Expected filter shape**:
+- `status:sold`
+- `purchase-date-start:2026-04-01`
+- `purchase-date-end:2026-06-30`
+
+**Validation expectation**: should match the user's actual booked count;
+non-zero unless they have no Q2 sales.
+
+**Notes**: tests date-range handling and the bookings convention
+(filter sold by `purchase_date`, not `created_at`).
+
+---
+
+### 5. Pending matches in tech
+
+**User says**: "I want to track pending matches with tech channels"
+
+**Expected report type**: SPONSORSHIPS
+
+**Expected topic match**: Technology / Computing (strong)
+
+**Expected filter shape**:
+- `status:matched` (or `status:pending` — skill should verify via describe)
+- topic / category alignment with tech
+
+**Validation expectation**: tens to hundreds.
+
+---
+
+### 6. High-CPM live ads last 90 days
+
+**User says**: "show me sold sponsorships with high CPM in the last 90 days"
+
+**Expected report type**: SPONSORSHIPS
+
+**Expected topic match**: none
+
+**Expected filter shape**:
+- `status:sold`
+- `publish-date-start:<90 days ago>`
+- (CPM is post-filter only — skill should note this)
+
+**Validation expectation**: result depends on user's pipeline.
+
+**Notes**: tests the documented CPM constraint — no range filter on the
+server, so the skill should either pull a wider set and apply CPM in
+post-processing or ask the user to relax the request.
+
+---
+
+## Brand / advertiser requests
+
+### 7. Brands in fitness
+
+**User says**: "build a report of brands advertising in the fitness space"
+
+**Expected report type**: BRANDS
+
+**Expected topic match**: Fitness / Health & Wellness (strong)
+
+**Expected filter shape**:
+- topic / category alignment with fitness
+
+**Validation expectation**: tens to a few hundred.
+
+---
+
+### 8. Brand history on a specific channel
+
+**User says**: "what brands has channel 12345 worked with — make it a saved report"
+
+**Expected report type**: SPONSORSHIPS (filtered by channel)
+
+**Expected topic match**: none
+
+**Expected filter shape**:
+- `channel:12345`
+- `status` filter to whatever the user means by "worked with" (likely sold)
+
+**Validation expectation**: matches `tl brands history --channel 12345 --json` count.
+
+**Notes**: skill should consider whether the user wants `tl brands history`
+(one-shot) versus a saved report (recurring).
+
+---
+
+## Content / upload requests
+
+### 9. Recent gaming long-form videos
+
+**User says**: "save a report of long-form gaming videos uploaded this month"
+
+**Expected report type**: CONTENT (uploads)
+
+**Expected topic match**: Gaming (strong)
+
+**Expected filter shape**:
+- topic / category alignment with gaming
+- `type:longform`
+- `publish-date-start:<first of month>`
+
+**Validation expectation**: hundreds to low thousands.
+
+---
+
+### 10. AI-themed videos with high views
+
+**User says**: "track high-performing AI videos from the last 30 days"
+
+**Expected report type**: CONTENT
+
+**Expected topic match**: Artificial Intelligence (strong)
+
+**Expected filter shape**:
+- topic / keyword expansion for AI
+- `publish-date-start:<30 days ago>`
+- view threshold (post-filter, depending on schema)
+
+**Validation expectation**: hundreds.
+
+---
+
+### 11. Multi-topic ambiguity
+
+**User says**: "I want a dashboard for AI cooking shows"
+
+**Expected report type**: CONTENT
+
+**Expected topic match**: AI **and** Food & Drink (both potentially strong)
+
+**Expected filter shape**: depends on disambiguation — skill should ask
+whether the user means AI-about-cooking, cooking-by-AI, or videos that hit
+both topics.
+
+**Validation expectation**: small (intersection); broad if the user
+clarifies they mean union.
+
+**Notes**: this is the canonical disambiguation case from Q2 of the
+architecture doc.
+
+---
+
+## Edge cases / failure modes
+
+### 12. Zero-result narrow query
+
+**User says**: "track UK kids' DIY origami channels with at least 1M subs"
+
+**Expected report type**: CHANNELS
+
+**Expected topic match**: weak (no clean topic for origami)
+
+**Expected filter shape**: keyword-expansion heavy.
+
+**Validation expectation**: zero — should trigger Phase 3 retry with
+broader keywords or `min-subs` relaxation.
+
+**Notes**: tests the validation loop's narrowing logic.
+
+---
+
+### 13. Enormous query
+
+**User says**: "show me all sponsorships ever"
+
+**Expected report type**: SPONSORSHIPS
+
+**Expected filter shape**: nothing → everything.
+
+**Validation expectation**: millions — should trigger Phase 3 narrowing.
+
+**Notes**: tests guardrails. Skill should ask for narrowing rather than
+build a filter-less report.
+
+---
+
+### 14. Vague request
+
+**User says**: "make me a report"
+
+**Expected report type**: ambiguous.
+
+**Expected behaviour**: skill asks a clarifying question rather than
+guessing. No FilterSet should be produced.
+
+---
+
+### 15. Wrong tool request
+
+**User says**: "how many sold deals last week?"
+
+**Expected behaviour**: this is a one-shot data question, not a
+report-building request. Skill should defer to the `tl` data-analyst
+skill or directly answer with `tl deals list status:sold ...`.
+
+**Notes**: tests the trigger boundary.
+
+---
+
+## Demographics-driven requests
+
+### 16. Young US mobile audience
+
+**User says**: "build a report for channels with a young US audience that watches on mobile"
+
+**Expected report type**: CHANNELS
+
+**Expected filter shape**:
+- `min-us-share:60`
+- `primary-device:mobile`
+- (age demographics — skill should verify available filters via describe)
+
+**Notes**: tests demographic-filter discovery.
+
+---
+
+### 17. International-skewing channels
+
+**User says**: "monitor channels whose audience is more than half outside the US"
+
+**Expected report type**: CHANNELS
+
+**Expected filter shape**:
+- inverse of `min-us-share` — verify whether `max-us-share` exists or
+  fall back to post-filter.
+
+**Notes**: tests negative-share filter handling.
+
+---
+
+## Time-based requests
+
+### 18. Booked-this-week tracker
+
+**User says**: "I want a recurring report of deals booked this week"
+
+**Expected report type**: SPONSORSHIPS / DEALS
+
+**Expected filter shape**:
+- `status:sold`
+- `purchase-date-start:<start of week>`
+
+**Validation expectation**: small to medium.
+
+**Notes**: tests rolling-window date semantics. Skill should consider
+whether the saved report uses an absolute or relative date range
+(`today`, `yesterday` keywords).
+
+---
+
+### 19. Year-over-year comparison
+
+**User says**: "build me a report comparing this quarter's sold deals to the same quarter last year"
+
+**Expected report type**: SPONSORSHIPS
+
+**Expected filter shape**: depends on whether the report supports
+side-by-side periods or whether the skill should suggest two saved reports.
+
+**Notes**: edge case — saved-report schema may not support multi-period.
+Skill should explain the limitation if it exists.
+
+---
+
+## Identifier-based requests
+
+### 20. Specific brand pipeline
+
+**User says**: "save a tracker for everything Nike-related in the pipeline"
+
+**Expected report type**: SPONSORSHIPS
+
+**Expected topic match**: none (brand-specific).
+
+**Expected filter shape**:
+- `brand:Nike` (or numeric brand ID — skill should resolve via
+  `tl brands show Nike`)
+
+**Validation expectation**: depends on Nike's actual pipeline volume.
+
+**Notes**: tests entity-resolution flow (name → ID).


### PR DESCRIPTION
Adds the v2 report-builder skill as a stub: SKILL.md describes the five-phase flow and trigger conditions, data/ holds placeholders for the topics snapshot and column metadata that will be synced from the platform repo, and examples/golden_queries.md seeds 20 hand-curated NL test cases for later milestones.