### PR TITLE
Add tl channels update / tl sponsorships update commands

### DIFF
--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -141,6 +141,7 @@ Prefer writing Python code, shell code, or `jq` commands that fetche or analysis
 tl sponsorships list [filters...]      # Sponsorships — list curve, mult 1.0
 tl sponsorships show <id>              # Sponsorship detail (2 credits)
 tl sponsorships create --channel <id> --brand <id>  # Create proposal (free)
+tl sponsorships update <id> '<json>'   # Update whitelisted fields (2 credits) — only `publish_status` editable; non-full-access users can only edit sponsorships in their own org
 tl deals list [filters...]             # Shortcut: agreed-upon sponsorships (status:deal); same curve as sponsorships list
 tl deals show <id>                     # Deal detail (2 credits)
 tl matches list [filters...]           # Shortcut: possible brand-channel pairings (status:match); same curve
@@ -152,6 +153,7 @@ tl proposals create --channel <id> --brand <id>  # Create proposal (free)
 tl uploads list [filters...]           # Video uploads from ES — list curve, mult 1.0
 tl uploads show <id>                   # Upload detail (2 credits)
 tl channels show <id-or-name>          # Channel detail (2 credits; accepts numeric ID or name) — for channel search use raw SQL on thoughtleaders_channel
+tl channels update <id> '<json>'       # Update whitelisted demographic fields (2 credits; full-access only)
 tl channels history <id-or-name>       # Sponsorship history (5 credits/result, linear)
 tl channels similar <id-or-name>       # Similarity recommender (25 credits flat; Intelligence plan)
 tl brands show <id-or-name>            # Brand detail (1 credit)
@@ -187,6 +189,30 @@ tl comments add <adlink-id> "msg"      # Add comment (free)
 | 500 | 219 | 263 | 285 | 307 |
 
 The marginal per-row cost is exactly proportional to `mult` — a 1.4× resource costs 1.4× the row part of a 1.0× resource at any size. Splitting a 500-row pull into ten 50-row calls saves ~30% but burns 10 setup floors instead of 1; "narrow the query" is almost always the better move than "fragment the pagination."
+
+### Updating records
+
+A narrow write surface is exposed for two resources. Each command takes the record id and a single JSON object with the fields to change; the server enforces a hard-coded field whitelist and rejects anything else with a 400. Each call costs 2 credits.
+
+```bash
+tl sponsorships update <id> '<json>'   # Edit a sponsorship (adlink)
+tl channels update <id> '<json>'       # Edit a channel
+```
+
+**Sponsorships** — only `publish_status` is editable. Accepts either an int code or a status label (`proposed`, `pending`, `sold`, `matched`, `outreach`, `proposal_approved`, `advertiser_reject`, `publisher_reject`, `agency_reject`, `unavailable`). Non-full-access users may only update sponsorships tied to their own organization (either through `creator_profile` or through the channel's `publication`). Trying to edit a sponsorship outside the user's org returns 403.
+
+**Channels** — only the demographic fields are editable: `demographic_usa_share` and `demographic_male_share` (integers 0–100), `demographic_age` / `demographic_device` / `demographic_geo` (JSON objects with numeric values). Requires full-access permission; non-full-access users get a 403. The `demographics_updated_at` timestamp is refreshed automatically when any whitelisted demographic field changes.
+
+Examples:
+```bash
+tl sponsorships update 98765 '{"publish_status": "sold"}'
+tl sponsorships update 98765 '{"publish_status": 3}'
+tl channels update 12345 '{"demographic_male_share": 62}'
+tl channels update 12345 '{"demographic_geo": {"US": 60, "UK": 12, "CA": 8}}'
+tl channels update 12345 '{"demographic_male_share": 55, "demographic_usa_share": 70}'
+```
+
+Anything outside these whitelists — price, cost, owner, channel name, etc. — is not editable through the CLI and must be done in the app or by a human with DB access.
 
 ### Raw queries (`tl db`)
 
@@ -310,6 +336,8 @@ See [references/business-glossary.md](references/business-glossary.md) for reven
 | Arbitrary read-only `SELECT` on Postgres | **Available** via `tl db pg`. | SELECT-only, mandatory `LIMIT ≤ 500` + `OFFSET`, only certain SQL forms are allowed. See `references/postgres-schema.md`. |
 | Cross-reference helpers ("channels proposed to brand X", "channels sponsored by MBN brands in last N days") | **Available** via `tl db pg`. | Write the join: `thoughtleaders_adlink` ↔ `adspot` ↔ `channel` ↔ `profile` ↔ `profile_brands` ↔ `brand`. Filter by `publish_status` for proposed/sold and by date range as needed. See `references/postgres-schema.md` for the exact column names. |
 | **AdLink INSERT** with custom price/cost/owner/`weighted_price`/`created_where` | **Unavailable** — `tl sponsorships create` exists but only creates a free *proposal* between a channel and a brand. The `tl db pg` sanitizer accepts SELECT only — no INSERT/UPDATE. | Done in the app or by a human with DB access. |
+| **AdLink UPDATE** of any field other than `publish_status` (price, cost, owner, send_date, …) | **Unavailable** — `tl sponsorships update` only accepts `publish_status` and only for sponsorships in the user's org (full-access bypasses the org check). | Done in the app or by a human with DB access. |
+| **Channel UPDATE** of any field other than the demographic fields (`demographic_usa_share`, `demographic_male_share`, `demographic_age`, `demographic_device`, `demographic_geo`) | **Unavailable** — `tl channels update` only accepts those fields, and only for full-access users. | Done in the app or by a human with DB access. |
 | Pre-insert validation queries (joining `adspot ↔ channel ↔ profile ↔ org` to confirm MSN, integration=1, persona, plan) | **Available** via `tl db pg`. | One SELECT joining the four tables. Use `thoughtleaders_channel.media_selling_network_join_date IS NOT NULL` for MSN, `thoughtleaders_adspot.integration = 1` for mention adspots, `thoughtleaders_profile.persona` for the persona code (see persona constants in `references/postgres-schema.md`). |
 | Firebolt cross-table or join queries; filtering on non-indexed columns in WHERE | **Unavailable** — not accepted. | Fetch a wider slice keyed on `channel_id` (and optionally `id`), filter the rest in `jq`/Python. |
 | ES `query_string`, `regexp`, `wildcard`, `fuzzy`, `more_like_this`, parent/child joins; any `script_*`; multiple aggregations in one body | **Unavailable** — not accepted. | Rewrite using `term`/`terms`/`match`/`bool`/`nested`. For multi-agg dashboards, run multiple `tl db es` calls and combine client-side. For "similar"-style queries, try `tl channels similar` / `tl brands similar` (server-implemented similarity search). |

--- a/src/tl_cli/commands/channels.py
+++ b/src/tl_cli/commands/channels.py
@@ -1,5 +1,6 @@
 """tl channels — Search and show YouTube channels."""
 
+import json as _json
 import urllib.parse
 
 import typer
@@ -228,6 +229,43 @@ def history_cmd(
         )
     except ApiError as e:
         _handle_channel_api_error(e)
+    finally:
+        client.close()
+
+
+@app.command("update")
+def update_cmd(
+    channel_id: int = typer.Argument(..., help="Channel ID (numeric)"),
+    fields: str = typer.Argument(..., help='JSON object of fields to update, e.g. \'{"demographic_male_share": 62}\''),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Update whitelisted channel fields (demographics; full-access only).
+
+    Editable fields: demographic_usa_share, demographic_male_share,
+    demographic_age, demographic_device, demographic_geo. The
+    demographics_updated_at timestamp is refreshed automatically.
+
+    Examples:
+        tl channels update 12345 '{"demographic_male_share": 62}'
+        tl channels update 12345 '{"demographic_geo": {"US": 60, "UK": 12}}'
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    try:
+        body = _json.loads(fields)
+    except _json.JSONDecodeError as exc:
+        Console(stderr=True).print(f"[red]Error:[/red] fields argument must be a JSON object: {exc}")
+        raise typer.Exit(1)
+    if not isinstance(body, dict):
+        Console(stderr=True).print("[red]Error:[/red] fields argument must be a JSON object.")
+        raise typer.Exit(1)
+
+    client = get_client()
+    try:
+        data = client.post(f"/channels/{channel_id}/edit", json_body=body)
+        output_single(data, fmt)
+    except ApiError as e:
+        handle_api_error(e)
     finally:
         client.close()
 

--- a/src/tl_cli/commands/sponsorships.py
+++ b/src/tl_cli/commands/sponsorships.py
@@ -1,5 +1,6 @@
 """tl sponsorships — List, show, and create sponsorships."""
 
+import json as _json
 from typing import Optional
 
 import typer
@@ -191,3 +192,40 @@ def create_cmd(
     """
     fmt = detect_format(json_output, False, False, toon_output)
     do_create(channel, brand, price, fmt, status="proposed")
+
+
+@app.command("update")
+def update_cmd(
+    sponsorship_id: int = typer.Argument(..., help="Sponsorship (adlink) ID"),
+    fields: str = typer.Argument(..., help='JSON object of fields to update, e.g. \'{"publish_status": "sold"}\''),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Update whitelisted sponsorship fields.
+
+    Editable fields: publish_status (int code or status label, e.g. 'sold',
+    'pending', 'matched'). Non-full-access users may only update sponsorships
+    tied to their own organization.
+
+    Examples:
+        tl sponsorships update 98765 '{"publish_status": "sold"}'
+        tl sponsorships update 98765 '{"publish_status": 3}'
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    try:
+        body = _json.loads(fields)
+    except _json.JSONDecodeError as exc:
+        Console(stderr=True).print(f"[red]Error:[/red] fields argument must be a JSON object: {exc}")
+        raise typer.Exit(1)
+    if not isinstance(body, dict):
+        Console(stderr=True).print("[red]Error:[/red] fields argument must be a JSON object.")
+        raise typer.Exit(1)
+
+    client = get_client()
+    try:
+        data = client.post(f"/sponsorships/{sponsorship_id}/edit", json_body=body)
+        output_single(data, fmt)
+    except ApiError as e:
+        handle_api_error(e)
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary
- New `tl sponsorships update <id> '<json>'` command — POSTs to `/sponsorships/<id>/edit`. Editable: `publish_status` (int code or label like `sold`).
- New `tl channels update <id> '<json>'` command — POSTs to `/channels/<id>/edit`. Editable: demographic fields only.
- Both are thin wrappers — the server enforces the field whitelist and authorization. Companion backend PR: ThoughtLeaders-io/thoughtleaders#3953.

## Test plan
- [x] `tl sponsorships update <id> '{\"publish_status\": \"sold\"}'` updates a sponsorship in your org.
- [x] `tl channels update <id> '{\"demographic_male_share\": 60}'` works as a full-access user.
- [x] Unknown field → server-side 400 surfaces cleanly.
- [x] Malformed JSON arg → CLI prints a clear error and exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)