### PR TITLE
Fix uv tool install resolution failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,19 @@ classifiers = [
     "Topic :: Office/Business",
 ]
 dependencies = [
-    "typer[all]>=0.12",
+    # `typer` >= 0.16 made click/rich/shellingham required — the `[all]` extra
+    # was removed and uv warns about it. Drop the extra to silence the warning;
+    # behaviour is identical because the bundled deps are pulled either way.
+    "typer>=0.16",
     "rich>=13.0",
     "httpx>=0.27",
     "keyring>=25.0",
     "authlib>=1.3",
-    "toon-format>=0.9.0b1",
+    # `toon-format` only publishes pre-releases (0.9.0b1 is the only modern
+    # release; 0.1.0 is the lone stable). pip/pipx accept `>=0.9.0b1` and pull
+    # the beta, but uv refuses pre-releases under `>=` when a stable exists.
+    # An exact pin is the one form uv will resolve without `--prerelease=allow`.
+    "toon-format==0.9.0b1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

`uv tool install thoughtleaders-cli` from PyPI was failing with an unsatisfiable-dependencies error. Two issues that pip/pipx accept silently but uv flags:

### 1. `toon-format>=0.9.0b1` → `==0.9.0b1`

\`toon-format\` only publishes \`0.1.0\` (stable) and \`0.9.0b1\` (the version we actually need). uv refuses pre-releases under a \`>=\` range when a stable version exists — only an exact pin opts into a pre-release without the user needing \`--prerelease=allow\`. pip/pipx silently allow it.

Repro before the fix:
\`\`\`
$ uv tool install thoughtleaders-cli
  × No solution found when resolving dependencies:
  ╰─▶ Because only toon-format<0.9.0b1 is available and all versions of
      thoughtleaders-cli depend on toon-format>=0.9.0b1, we can conclude that
      all versions of thoughtleaders-cli cannot be used.
\`\`\`

### 2. \`typer[all]>=0.12\` → \`typer>=0.16\`

typer ≥ 0.16 made click / rich / shellingham required deps and removed the \`[all]\` extra. uv emits \`warning: The package typer==0.25.1 does not have an extra named all\`. Behaviour is unchanged.

## Test plan

- [x] \`uv tool install --force .\` from a clean uninstall — resolves cleanly, no warnings.
- [x] \`tl --version\`, \`tl whoami\`, \`tl sponsorships list\`, \`tl describe\`, \`tl doctor\`, \`tl setup claude\`, \`tl setup opencode\` all work end-to-end against the uv-installed CLI.
- [ ] After merge + release: confirm \`uv tool install thoughtleaders-cli\` from PyPI resolves on a fresh machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)