### PR TITLE
v0.6.12: tl reports update + tl reports create --config

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.11"
+version = "0.6.12"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.11"
+__version__ = "0.6.12"

--- a/src/tl_cli/commands/reports.py
+++ b/src/tl_cli/commands/reports.py
@@ -10,9 +10,9 @@ from rich.text import Text
 
 from tl_cli.client.errors import ApiError, handle_api_error
 from tl_cli.client.http import get_client
-from tl_cli.output.formatter import detect_format, output
+from tl_cli.output.formatter import detect_format, output, output_single
 
-app = typer.Typer(help="Saved reports (list, run, create)")
+app = typer.Typer(help="Saved reports (list, run, create, update)")
 err = Console(stderr=True)
 
 # Report type labels matching Django's ReportType enum
@@ -226,75 +226,122 @@ def _handle_follow_up(result: dict) -> str:
     return answer
 
 
+def _parse_config_arg(config_json: str) -> dict:
+    """Parse the --config argument string into a dict, exiting cleanly on bad input."""
+    try:
+        config = json.loads(config_json)
+    except json.JSONDecodeError as exc:
+        err.print(f"[red]--config is not valid JSON: {exc}[/red]")
+        raise typer.Exit(1)
+    if not isinstance(config, dict):
+        err.print("[red]--config must be a JSON object.[/red]")
+        raise typer.Exit(1)
+    return config
+
+
+def _orchestrate_via_server(
+    client,
+    prompt: str,
+    timeout: int,
+    json_output: bool,
+) -> dict:
+    """Run the server-side AI Report Builder loop and return the resulting config."""
+    conversation: list[dict[str, str]] = []
+    current_prompt = prompt
+
+    while True:
+        # Send prompt to server, poll for result
+        try:
+            create_data = client.post("/reports/create", json_body={
+                "prompt": current_prompt,
+                "conversation": conversation,
+            })
+        except ApiError as e:
+            if e.status_code == 503:
+                err.print("[red]AI Report Builder is temporarily unavailable. Please try again later.[/red]")
+                raise typer.Exit(1)
+            handle_api_error(e)
+            raise typer.Exit(1)
+
+        task_id = create_data.get("task_id")
+        if not task_id:
+            err.print("[red]Server did not return a task ID.[/red]")
+            raise typer.Exit(1)
+
+        result = _poll_for_result(client, task_id, timeout)
+        action = result.get("action", "")
+
+        if action == "follow_up":
+            answer = _handle_follow_up(result)
+            conversation.append({"role": "user", "content": current_prompt})
+            conversation.append({"role": "assistant", "content": result.get("question", "")})
+            current_prompt = answer
+            continue
+
+        if action in ("error", "unsupported"):
+            message = result.get("message", "Request could not be processed.")
+            err.print(f"\n[red]{message}[/red]")
+            raise typer.Exit(1)
+
+        if action == "preview":
+            return result.get("config", {})
+        if action == "create_report":
+            return result
+
+        err.print(f"[yellow]Unexpected action: {action}[/yellow]")
+        if json_output:
+            print(json.dumps(result, indent=2, default=str))
+        raise typer.Exit(1)
+
+
 @app.command("create")
 def create_report(
-    prompt: str = typer.Argument(..., help="Natural language description of the report you want"),
+    prompt: str | None = typer.Argument(
+        None,
+        help="Natural language description of the report you want. Omit when using --config.",
+    ),
+    config_json: str | None = typer.Option(
+        None,
+        "--config",
+        help=(
+            "Pre-built report config as JSON. Skips the AI Report Builder "
+            "pipeline and saves the config directly. Mutually exclusive with "
+            "the prompt argument."
+        ),
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON config"),
     timeout: int = typer.Option(300, "--timeout", help="Max orchestration time in seconds"),
 ) -> None:
-    """Create a report from a natural language description.
+    """Create a report from a natural-language prompt or a pre-built config.
 
-    Sends your prompt to the ThoughtLeaders server, which runs the AI Report
-    Builder pipeline (keyword research, config generation, review). Then
-    confirms with the server to create the campaign.
+    With a prompt, runs the AI Report Builder pipeline (keyword research, config
+    generation, review) and saves the resulting campaign.
+
+    With --config '<json>', skips the orchestration pipeline and saves the
+    provided config directly. Useful when an external agent (e.g. the
+    tl-report-builder Claude Code skill) has already produced a validated
+    config and you just want to persist it.
 
     Examples:
         tl reports create "gaming channels sponsoring energy drinks"
         tl reports create "tech review channels with 100K+ subscribers" --yes
-        tl reports create "beauty brands on YouTube" --json
+        tl reports create --config "$(cat config.json)" --yes
     """
+    if (prompt is None) == (config_json is None):
+        err.print(
+            "[red]Provide either a natural-language prompt OR --config '<json>', not both.[/red]"
+        )
+        raise typer.Exit(1)
+
     client = get_client()
     try:
-        conversation: list[dict[str, str]] = []
-        current_prompt = prompt
-
-        while True:
-            # Send prompt to server, poll for result
-            try:
-                create_data = client.post("/reports/create", json_body={
-                    "prompt": current_prompt,
-                    "conversation": conversation,
-                })
-            except ApiError as e:
-                if e.status_code == 503:
-                    err.print("[red]AI Report Builder is temporarily unavailable. Please try again later.[/red]")
-                    raise typer.Exit(1)
-                handle_api_error(e)
-                raise typer.Exit(1)
-
-            task_id = create_data.get("task_id")
-            if not task_id:
-                err.print("[red]Server did not return a task ID.[/red]")
-                raise typer.Exit(1)
-
-            result = _poll_for_result(client, task_id, timeout)
-            action = result.get("action", "")
-
-            # Server wraps response: "preview" → config in result["config"]
-            if action == "follow_up":
-                answer = _handle_follow_up(result)
-                conversation.append({"role": "user", "content": current_prompt})
-                conversation.append({"role": "assistant", "content": result.get("question", "")})
-                current_prompt = answer
-                continue
-
-            if action in ("error", "unsupported"):
-                message = result.get("message", "Request could not be processed.")
-                err.print(f"\n[red]{message}[/red]")
-                raise typer.Exit(1)
-
-            if action == "preview":
-                config = result.get("config", {})
-            elif action == "create_report":
-                config = result
-            else:
-                err.print(f"[yellow]Unexpected action: {action}[/yellow]")
-                if json_output:
-                    print(json.dumps(result, indent=2, default=str))
-                raise typer.Exit(1)
-
-            break
+        if config_json is not None:
+            config = _parse_config_arg(config_json)
+            saved_prompts: list[str] = []
+        else:
+            config = _orchestrate_via_server(client, prompt, timeout, json_output)
+            saved_prompts = [prompt]
 
         # --- Show preview ---
         if json_output:
@@ -315,7 +362,7 @@ def create_report(
         # --- Save to server ---
         data = client.post("/reports/confirm", json_body={
             "config": config,
-            "prompts": [prompt],
+            "prompts": saved_prompts,
             "reasoning": "",
         })
 
@@ -340,6 +387,47 @@ def create_report(
             if usage:
                 err.print(f"\n  [dim]{usage.get('credits_charged', 0)} credits · {usage.get('balance_remaining', '?')} remaining[/dim]")
 
+    except ApiError as e:
+        handle_api_error(e)
+    finally:
+        client.close()
+
+
+@app.command("update")
+def update_report(
+    report_id: int = typer.Argument(..., help="Report (Campaign) ID"),
+    fields: str = typer.Argument(
+        ...,
+        help='JSON object of fields to update, e.g. \'{"title": "Q4 gaming pipeline"}\'',
+    ),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Update fields on a saved report.
+
+    Edits route through the canonical campaign-update path. The owner of the
+    report (or a full-access user) may update fields like title, description,
+    columns, widgets, histogram_bucket_size. Unknown fields come back as 400.
+
+    Examples:
+        tl reports update 12345 '{"title": "Q4 gaming pipeline"}'
+        tl reports update 12345 '{"description": "Refreshed Apr 2026"}'
+        tl reports update 12345 '{"columns": {"Channel": {"display": true}}}'
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    try:
+        body = json.loads(fields)
+    except json.JSONDecodeError as exc:
+        err.print(f"[red]Error:[/red] fields argument must be a JSON object: {exc}")
+        raise typer.Exit(1)
+    if not isinstance(body, dict):
+        err.print("[red]Error:[/red] fields argument must be a JSON object.")
+        raise typer.Exit(1)
+
+    client = get_client()
+    try:
+        data = client.post(f"/reports/{report_id}/edit", json_body=body)
+        output_single(data, fmt)
     except ApiError as e:
         handle_api_error(e)
     finally:

--- a/src/tl_cli/commands/reports.py
+++ b/src/tl_cli/commands/reports.py
@@ -243,7 +243,6 @@ def _orchestrate_via_server(
     client,
     prompt: str,
     timeout: int,
-    json_output: bool,
 ) -> dict:
     """Run the server-side AI Report Builder loop and return the resulting config."""
     conversation: list[dict[str, str]] = []
@@ -289,8 +288,7 @@ def _orchestrate_via_server(
             return result
 
         err.print(f"[yellow]Unexpected action: {action}[/yellow]")
-        if json_output:
-            print(json.dumps(result, indent=2, default=str))
+        err.print(json.dumps(result, indent=2, default=str))
         raise typer.Exit(1)
 
 
@@ -340,7 +338,7 @@ def create_report(
             config = _parse_config_arg(config_json)
             saved_prompts: list[str] = []
         else:
-            config = _orchestrate_via_server(client, prompt, timeout, json_output)
+            config = _orchestrate_via_server(client, prompt, timeout)
             saved_prompts = [prompt]
 
         # --- Show preview ---
@@ -395,24 +393,14 @@ def create_report(
 
 @app.command("update")
 def update_report(
-    report_id: int = typer.Argument(..., help="Report (Campaign) ID"),
-    fields: str = typer.Argument(
-        ...,
-        help='JSON object of fields to update, e.g. \'{"title": "Q4 gaming pipeline"}\'',
-    ),
+    report_id: int = typer.Argument(..., help="Report ID"),
+    fields: str = typer.Argument(..., help='JSON object of fields to update'),
     json_output: bool = typer.Option(False, "--json", help="JSON output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
 ) -> None:
-    """Update fields on a saved report.
+    """Update a saved report.
 
-    Edits route through the canonical campaign-update path. The owner of the
-    report (or a full-access user) may update fields like title, description,
-    columns, widgets, histogram_bucket_size. Unknown fields come back as 400.
-
-    Examples:
-        tl reports update 12345 '{"title": "Q4 gaming pipeline"}'
-        tl reports update 12345 '{"description": "Refreshed Apr 2026"}'
-        tl reports update 12345 '{"columns": {"Channel": {"display": true}}}'
+    Unknown fields are rejected with a 400 listing the offending key.
     """
     fmt = detect_format(json_output, False, False, toon_output)
     try:

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,79 @@
+"""Tests for `tl reports create --config` and `tl reports update`."""
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from tl_cli.commands.reports import _parse_config_arg, app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# _parse_config_arg
+# ---------------------------------------------------------------------------
+
+
+class TestParseConfigArg:
+    def test_valid_object_returns_dict(self) -> None:
+        result = _parse_config_arg('{"report_title": "Test", "report_type": 3}')
+        assert result == {"report_title": "Test", "report_type": 3}
+
+    def test_invalid_json_exits(self) -> None:
+        with pytest.raises(typer.Exit) as excinfo:
+            _parse_config_arg('{not json')
+        assert excinfo.value.exit_code == 1
+
+    def test_non_object_exits(self) -> None:
+        # JSON arrays / strings / numbers are valid JSON but not the object the
+        # endpoint accepts.
+        with pytest.raises(typer.Exit) as excinfo:
+            _parse_config_arg('[1, 2, 3]')
+        assert excinfo.value.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# tl reports create — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateArgValidation:
+    def test_no_prompt_and_no_config_rejected(self) -> None:
+        result = runner.invoke(app, ["create"])
+        assert result.exit_code == 1
+        assert "either" in (result.stderr or result.output).lower() and "config" in (result.stderr or result.output).lower()
+
+    def test_both_prompt_and_config_rejected(self) -> None:
+        result = runner.invoke(
+            app,
+            ["create", "gaming channels", "--config", '{"report_title": "x", "report_type": 3}'],
+        )
+        assert result.exit_code == 1
+        assert "either" in (result.stderr or result.output).lower()
+
+    def test_config_invalid_json_rejected(self) -> None:
+        result = runner.invoke(app, ["create", "--config", "{not json", "--yes"])
+        assert result.exit_code == 1
+        assert "valid json" in (result.stderr or result.output).lower()
+
+    def test_config_non_object_rejected(self) -> None:
+        result = runner.invoke(app, ["create", "--config", "[1,2,3]", "--yes"])
+        assert result.exit_code == 1
+        assert "json object" in (result.stderr or result.output).lower()
+
+
+# ---------------------------------------------------------------------------
+# tl reports update — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateArgValidation:
+    def test_invalid_json_rejected(self) -> None:
+        result = runner.invoke(app, ["update", "12345", "{not json"])
+        assert result.exit_code == 1
+        assert "json object" in (result.stderr or result.output).lower()
+
+    def test_non_object_rejected(self) -> None:
+        result = runner.invoke(app, ["update", "12345", '"just a string"'])
+        assert result.exit_code == 1
+        assert "json object" in (result.stderr or result.output).lower()


### PR DESCRIPTION
## Summary

- Add `--config '<json>'` flag to `tl reports create` — skips the server-side AI orchestration and saves a pre-built config directly. The tl-report-builder skill produces this JSON in chat; this flag is how it gets persisted in one command.
- Add `tl reports update <id> '<json>'` — thin wrapper over the new `/api/cli/v1/reports/<pk>/edit` endpoint. Mirrors the existing \`tl sponsorships update\` / \`tl channels update\` patterns.
- Bump version to 0.6.12 (pyproject.toml + plugin.json + __init__.py).

## Why

After the skill's Phase 4 emits a validated `campaign_config_json` in chat, the only way to persist it before this PR was to manually \`curl\` the JSON to the confirm endpoint. With \`--config\`, it's:

\`\`\`bash
tl reports create --config "$(cat config.json)" --yes
\`\`\`

The existing NL flow (\`tl reports create \"gaming channels\"\`) is unchanged — it still runs the server-side pipeline. Argument validation enforces exactly one of (prompt, --config).

## Examples

\`\`\`bash
# Existing — natural language → server-side AI pipeline (unchanged)
tl reports create "gaming channels sponsoring energy drinks"

# New — pre-built config (e.g. from the skill)
tl reports create --config '{"report_title": "...", "report_type": 3, "filterset": {...}}' --yes

# New — edit a saved report
tl reports update 12345 '{"title": "Q4 gaming pipeline"}'
tl reports update 12345 '{"description": "Refreshed Apr 2026", "columns": {...}}'
\`\`\`

## Test plan

- [x] 9 unit tests covering argument-validation edges (\`pytest tests/test_reports.py\` — all green locally)
- [ ] Manual smoke against staging once deployed:
  - \`tl reports create --config '<skill output>' --yes\` → Campaign appears in DB, URL printed
  - \`tl reports update <existing-id> '{"title": "x"}'\` → 200 + title persisted
  - \`tl reports create\` with no args → 1 with "either prompt OR --config" message
  - \`tl reports create "x" --config '{}'\` → 1 with same message

## Depends on

- thoughtleaders #3978 (preprocessor extraction) — merged
- thoughtleaders #3979 (CLI report-edit endpoint + cross_references fix) — merged

Both already on master in the thoughtleaders repo. \`tl reports update\` will return 404 until those changes deploy to whatever environment the CLI is hitting.