### PR TITLE
v0.6.13: skill teaches tl reports create --config (not UI paste)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.12"
+version = "0.6.13"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -226,9 +226,9 @@ USER_QUERY
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-There is no fifth phase. Phase 4's output IS the deliverable: a complete, validated campaign config + takeaways. The save step happens **outside the skill**, via a `POST` (create) or `PUT` (edit) to the report-creation API endpoint. The skill itself never writes to the database directly — reads use raw `tl db es` (intelligence reports — types 1/2/3) or raw `tl db pg` (sponsorship reports — type 8); writes go through the API.
+There is no fifth phase. Phase 4's output IS the deliverable: a complete, validated campaign config + takeaways. The save step happens **outside the skill**, by handing the JSON to `tl reports create --config '<json>' --yes`. The skill itself never writes to the database directly — reads use raw `tl db es` (intelligence reports — types 1/2/3) or raw `tl db pg` (sponsorship reports — type 8); writes go through the CLI command, which posts to the report-creation API.
 
-> **Save-mechanism policy**: A new API endpoint is required for report creation. It will support both `POST` (initial create) and `PUT` (subsequent edits) so reports can be modified without redoing the four phases from scratch. Until the endpoint is built, the skill stops at producing the JSON config + takeaways; the calling environment handles whatever save mechanism is current. **Reads via `tl db es` / `tl db pg` (engine routed by report type — see Step 2.V1), writes via the API** is the architectural split.
+> **Save-mechanism policy**: After Phase 4 emits the config, the skill instructs the user to run `tl reports create --config '<json>' --yes` to persist it. Edits to a saved report use `tl reports update <id> '<json>'`. Both commands route to the report-creation API endpoint, which delegates to the canonical campaign-update path. **Reads via `tl db es` / `tl db pg` (engine routed by report type — see Step 2.V1), writes via the CLI** is the architectural split. Do NOT instruct the user to paste the JSON into the platform UI — that's an obsolete pre-v0.6.12 fallback.
 
 ## Phase 1 — Report Type Selection (detail)
 
@@ -1327,7 +1327,7 @@ USER: Build me a report of gaming channels with 100K+ subscribers in English
 
 Claude follows this SKILL.md, executing each phase in order. No external command needed — the skill IS the orchestration; `tl db pg` is invoked from within Phase 2/3/4 as needed; tools fire conditionally per their criteria.
 
-> **Note**: how the final config is committed (DB insert path vs. UI paste vs. another mechanism) is being addressed separately. For now Phase 4 produces the validated JSON + takeaways and stops there.
+> **Saving the config**: after Phase 4 prints the JSON, instruct the user to run `tl reports create --config '<paste the JSON>' --yes` (tl-cli ≥ v0.6.12). For edits to an existing saved report, use `tl reports update <report_id> '<json patch>'`. Do NOT tell users to paste into the platform UI — that's an obsolete fallback from before the CLI commands existed.
 
 ## Reference Files
 

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.12"
+__version__ = "0.6.13"


### PR DESCRIPTION
## Summary

The tl-report-builder skill's SKILL.md still tells Claude that saving happens "outside the skill" via "POST/PUT to the report-creation API endpoint" — and notes the endpoint as future work. As of v0.6.12 that endpoint exists and is wrapped by:

- \`tl reports create --config '<json>' --yes\`
- \`tl reports update <id> '<json>'\`

Update the two save-mechanism notes in \`skills/tl-report-builder/SKILL.md\` to point at the actual CLI commands and explicitly tell Claude **not** to fall back to "paste the JSON into the platform UI", which was the obsolete pre-v0.6.12 fallback. Symptom: a recent skill run printed "save from the skill is unavailable. Two options: 1. Copy this JSON and paste into the AI Report Builder UI..." — that wording is now wrong.

## What changed

\`skills/tl-report-builder/SKILL.md\`:
- Two notes (lines 150, 1188) updated to instruct Claude to emit \`tl reports create --config '<json>' --yes\` after Phase 4
- Both notes explicitly forbid the UI-paste fallback

Version bump 0.6.12 → 0.6.13 (pyproject.toml + plugin.json + __init__.py per AGENTS.md).

## Test plan

- [ ] After release, run the skill in Claude Code with a query like "build me gaming channels with 100K+ subs". Verify the final message instructs the user to run \`tl reports create --config '...' --yes\` and does **not** suggest pasting into the UI.