### PR TITLE
v0.6.15: tighten skill save policy — /tmp only, file write != save

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.14"
+version = "0.6.15"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -54,8 +54,8 @@ Internally this skill thinks in phases (1–4), report types (1, 2, 3, 8), tool 
 | Phase 3 — column builder | "Picking which columns to show in the report…" |
 | Phase 4 — widget builder | "Choosing the charts and dashboards…" |
 | Phase 4 — final composition | "Putting the final report together…" |
-| Save step (write JSON to temp file, then `tl reports create --config-file <path> --yes`) | "Saving the report…" |
-| Save success | "Report saved." + link (do NOT echo the JSON config back) |
+| Save step (write JSON to `/tmp/<name>.json`, then `tl reports create --config-file /tmp/<name>.json --yes`) | "Saving the report…" |
+| Save success (only after the CLI command returns success) | "Report saved." + link from the CLI response (do NOT echo the JSON config back; do NOT say "saved as <path>.json" — the temp file is transport, not the deliverable) |
 | Save failure | "Couldn't save the report: <plain-English reason>" — surface the CLI's stderr verbatim if it's user-readable, otherwise summarise |
 | Mode B follow-up (looks_wrong) | "The top results don't look right — here are your options…" |
 | Mode C (3 retries exhausted) | "I couldn't build a sensible result for this — here's what I tried…" |
@@ -238,15 +238,18 @@ USER_QUERY
 
 There is no fifth phase. Phase 4's output IS the deliverable: a complete, validated campaign config + takeaways. The skill itself never writes to the database directly — reads use raw `tl db es` (intelligence reports — types 1/2/3) or raw `tl db pg` (sponsorship reports — type 8); writes go through `tl reports create --config-file <path> --yes`, which posts to the report-creation API.
 
-> **Save-mechanism policy**: After Phase 4 produces the config, the agent **saves the report automatically** by:
-> 1. **Writing the JSON to a temp file** via the `Write` tool (e.g. `/tmp/tl-report-builder-config.json` or any path the agent has write access to). Never inline the JSON inside a shell command — apostrophes in titles, keywords, or descriptions ("McDonald's", "L'Oréal", "channels we've worked with") break shell quoting and the command fails before `tl` runs.
-> 2. **Invoking `tl reports create --config-file <path> --yes`** via the `Bash` tool. The file transport is shell-quote-safe regardless of what the JSON contains.
+> **Save-mechanism policy**: After Phase 4 produces the config, the agent **saves the report automatically** by performing BOTH of these steps. **Step 1 alone is not the save** — the file write is just transport for step 2. Saying "Saved as foo.json" or "Saved to <path>" after only doing step 1 is a regression bug; a save means a Campaign row exists in the database with a real URL.
 >
-> The user sees only the takeaways and the resulting campaign link — the raw JSON config stays out of the conversation, because it's noise once the report is saved.
+> 1. **Write the JSON to `/tmp/`** via the `Write` tool. The path **MUST** be under the system temp directory (`/tmp/` on Linux/macOS, `%TEMP%` / `$TMPDIR` on whatever platform the agent is running on). Use a name like `/tmp/tl-report-builder-<short-slug>.json`. **Never write to the user's current working directory or any project path** — the file is a transport, not a deliverable, and leaving `foo_report.json` in the user's repo or cwd pollutes their workspace. If the system temp dir isn't writable, fall back to another temp-shaped location, never to cwd.
+> 2. **Invoke `tl reports create --config-file <that-same-tmp-path> --yes`** via the `Bash` tool. This is what actually saves the report. Read the CLI's response: success returns a `campaign_id` and `report_url` to echo to the user; failure returns a non-zero exit and an error message — surface that error verbatim, do NOT silently mark the report as saved.
+>
+> **Why two steps**: passing the JSON inline as `--config '<json>'` breaks the moment any value contains an apostrophe ("McDonald's", "L'Oréal"). The temp file sidesteps shell quoting entirely. But the file ON ITS OWN saves nothing — it has to be handed to the CLI in step 2.
+>
+> The user sees only the takeaways and the campaign link returned by step 2 — the raw JSON config stays out of the conversation, because it's noise once the report is saved.
 >
 > **Skip auto-save** when the user's wording signals they want to review the config first (e.g. "draft a config", "preview a report", "show me the config first", "what would the JSON look like", "without saving"). In that case, emit the JSON inline + the "to save, run …" hint and stop. The default for "build / create / make / save / report / campaign" wordings is auto-save.
 >
-> **Edits** to a saved report use `tl reports update <id> '<json>'` — same auto-invoke pattern, with the same shell-quoting caveat: when the patch contains apostrophes, write to a temp file and use `tl reports update <id> "$(cat <path>)"`. Don't tell users to paste JSON into the platform UI; that's an obsolete pre-v0.6.12 fallback.
+> **Edits** to a saved report use `tl reports update <id> '<json>'` — same auto-invoke pattern, with the same shell-quoting caveat: when the patch contains apostrophes, write to a `/tmp/` file and use `tl reports update <id> "$(cat /tmp/<patch>.json)"`. Don't tell users to paste JSON into the platform UI; that's an obsolete pre-v0.6.12 fallback.
 >
 > **Reads via `tl db es` / `tl db pg` (engine routed by report type — see Step 2.V1), writes via the CLI** is the architectural split.
 
@@ -1295,6 +1298,8 @@ Pseudo-shape (not runnable JSON — `<int>`, `|`-unions, and `/* notes */` are p
 7. **Type-8 axis consistency.** Both `_over_<axis>` histograms in the same type-8 report use the SAME axis (per `sponsorship_widget_schema.json`'s `_tl_axis_branching`).
 8. **Don't echo `campaign_config_json` back to chat.** The JSON is written to a temp file and passed to `tl reports create --config-file <path> --yes`; once the report is saved the JSON is implementation noise. The user-facing reply is takeaways + the resulting campaign link. Only show the JSON inline when the user has explicitly asked to review-before-save (see "Save-mechanism policy" above).
 9. **Use `--config-file <path>`, not `--config '<json>'`, for auto-save.** Passing JSON inline through a single-quoted shell argument breaks the moment any string value contains an apostrophe (which is common — "McDonald's", "L'Oréal", channel/title text). The temp-file transport sidesteps shell quoting entirely.
+10. **Temp file MUST be under `/tmp/`** (or `$TMPDIR` / `%TEMP%` — the system temp directory). Never write the transport file to the user's current working directory, project root, repo, or any other path they might be looking at. Pollution of cwd with `foo_report.json` is a regression bug.
+11. **Writing the file is NOT saving the report.** The save happens when `tl reports create --config-file <path> --yes` returns success. Until that command's exit code is read, the report does not exist. **Never tell the user "saved as <path>.json"** — that confuses the transport file (which is throwaway) with the saved Campaign (which is what they asked for). The save-success message must come from the CLI response: a `campaign_id` and `report_url`.
 
 ## Follow-Up Interactions
 

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.14"
+__version__ = "0.6.15"


### PR DESCRIPTION
## Summary

Two regressions observed running v0.6.14 in the wild:

1. **Transport file ended up in the user's CWD.** The agent wrote \`./insta360_tpp_report.json\` instead of \`/tmp/...\`. The previous policy's hedge — "any path the agent has write access to" — was read as "any path you like", and the file landed in the user's repo / project root.
2. **Agent stopped after writing the file.** The skill said \"Saved as insta360_tpp_report.json\" without ever invoking \`tl reports create --config-file\`. The two-step structure (write file → invoke CLI) wasn't strict enough about step 2 being mandatory; the agent treated step 1 as the save.

Both bugs leak from the same loose phrasing in the policy. This PR tightens both.

## Changes

- **Save-mechanism policy** now mandates \`/tmp/\` (or \`$TMPDIR\` / \`%TEMP%\` — the platform-equivalent system temp directory). Explicitly forbids cwd, project paths, anywhere the user might be looking. The phrase "or any path the agent has write access to" is gone.
- **Two new Phase 4 hard rules**:
  - **Rule 10**: Temp file MUST be under \`/tmp/\`. Pollution of cwd is a regression bug.
  - **Rule 11**: Writing the file is NOT saving the report. The save happens when \`tl reports create --config-file <path> --yes\` returns success with a \`campaign_id\` + \`report_url\`. Never say \"Saved as <path>.json\" — that confuses the throwaway transport file with the saved Campaign.
- **Narration map**: the Save-step row now shows \`/tmp/<name>.json\` explicitly. The Save-success row is gated on \"only after the CLI command returns success\" and re-iterates \"do NOT say 'saved as <path>.json'\".

## Why no code change

This is purely skill content. The CLI's \`--config-file\` flag (added in v0.6.14) is correct; the issue is how the agent was instructed to use it. Skill content lives in the plugin, so the version bump 0.6.14 → 0.6.15 is required even though no Python changed.

## Test plan

- [ ] In a Claude Code session with v0.6.15 installed, run: *\"Build me a report of TPP × Insta360 channels\"*. Expected:
  - Skill narrates phases.
  - Writes JSON to \`/tmp/tl-report-builder-<slug>.json\` (verify with \`ls -la /tmp/tl-report-builder-*.json\`).
  - **No JSON file appears in the user's cwd** (\`ls -la *.json\` in the working directory should not show a new file).
  - Runs \`tl reports create --config-file /tmp/...\` itself.
  - Reply contains a campaign URL and a campaign ID — not "Saved as <path>.json".
- [ ] Try with an apostrophe in the user prompt (e.g. \"build me a report for McDonald's pipeline\"). The temp-file path keeps the apostrophe inside the file content; shell never sees it. Save should succeed.