### PR TITLE
fix(hooks): wrap hooks.json contents in top-level "hooks" key

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,26 +1,28 @@
 {
-  "PreToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-check.sh",
-          "timeout": 10
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-usage.sh",
-          "timeout": 5
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-check.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-usage.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Wraps `PreToolUse` / `PostToolUse` in a top-level `"hooks"` object so `hooks/hooks.json` matches the Claude Code plugin schema.
- Without this, `claude plugin list` reports the plugin as "failed to load" and the Bash pre/post hooks never run on the marketplace install.

## Test plan
- [x] `claude plugin update tl-cli@thoughtleaders-plugins` on a machine that previously hit the load error
- [x] `claude plugin list` shows the plugin loaded (no `Hook load failed` error)
- [x] After a Claude Code restart, running any Bash tool call triggers `hooks/scripts/pre-check.sh` and `hooks/scripts/post-usage.sh`

Fixes #23