### PR TITLE
agents: adopt version-bump-on-main policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,25 @@ Every data query costs credits (rates vary by resource). `tl describe` shows rat
 
 ## Version Bumps
 
-The version string is defined in three files and all three must be updated together:
+The version string is defined in three files and all three must be updated together when a bump happens:
 - `pyproject.toml` — `version = "x.y.z"`
 - `.claude-plugin/plugin.json` — `"version": "x.y.z"`
 - `src/tl_cli/__init__.py` — `__version__ = "x.y.z"`
+
+### Where the bump goes — main, NOT the PR branch
+
+**Do not bump the version in a PR branch.** Version bumps land on `main` as a separate dedicated commit, made by whoever is cutting the release, immediately before tagging.
+
+Rationale: when multiple PRs are open at the same time, each pre-claiming a version number, merging them in different orders produces stale-version conflicts (PR A bumps to 0.6.22 → merges → main is 0.6.22; PR B was also bumping to 0.6.22 → needs rebase to 0.6.23; if PR B sat for a while, by the time it lands main might be 0.6.24 already). The fix is to keep PR branches version-neutral: PRs contain only the substantive change; the version-bump commit is owned by the release flow on main.
+
+What this means in practice:
+
+- **Opening a PR**: leave `pyproject.toml`, `.claude-plugin/plugin.json`, and `src/tl_cli/__init__.py` unchanged. The PR's diff against main should not touch those three files.
+- **Naming a PR**: use a descriptive title (`hotfix: scrub Campaign jargon`, `speed-up: retry cap + narrow-first`) rather than a version-claiming title (`v0.6.22: …`). The actual version assigned at release time is the release-cutter's call.
+- **Cutting a release** (release-cutter only, on `main` after the substantive PRs have merged): make one commit titled `vX.Y.Z: bump version` that updates all three files, then tag `vX.Y.Z` against that commit. Push the tag.
+- **Stacking PRs**: stacked PRs don't need to coordinate version numbers — the entire stack lands version-neutral, and the release-cutter bumps once on main covering all the changes in the stack.
+
+If you find yourself about to edit any of the three version files in a PR branch, stop. That file goes to main with the release commit, not to the PR.
 
 ## Important Constraint
 


### PR DESCRIPTION
Adopt the standard Ivan-Voras-style policy: **version bumps land on main as a separate commit by the release-cutter, immediately before tagging. PR branches are version-neutral.**

## Why now

This repo has been bitten twice by version-in-PR conflicts:

- **PR #25 (v0.6.21)**: claimed v0.6.20 while open; main shipped v0.6.20 separately (Rich-tree schema feature); after rebase the PR needed a manual bump to v0.6.21.
- **PR #26 (v0.6.22) and PR #27 (v0.6.23) right now**: both currently bump versions in their branches; merging either one forces the other to rebase its version bump. Whoever lands second eats the rebase cost.

The pattern repeats every release. Easy fix: stop bumping in PR branches.

## What this PR changes

`AGENTS.md` "Version Bumps" section gains a new "Where the bump goes" subsection that says:

1. **PR branches** — leave `pyproject.toml`, `.claude-plugin/plugin.json`, and `src/tl_cli/__init__.py` unchanged. Diff against main shouldn't touch those three files.
2. **PR titles** — descriptive (`hotfix: scrub Campaign jargon`), not version-claiming (`v0.6.22: …`).
3. **Release-cutter on main** — makes one commit `vX.Y.Z: bump version` covering all three files, then tags against that commit.
4. **Stacked PRs** — land version-neutral; one bump on main covers the entire stack.

The rule of thumb: *"if you find yourself about to edit any of the three version files in a PR branch, stop. That file goes to main with the release commit, not to the PR."*

## Follow-up PRs

Once this policy lands on main, two existing open PRs need revert-version commits to come into compliance:

- [`PR #26`](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/26) — revert version to 0.6.21
- [`PR #27`](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/27) — revert version to 0.6.21

I'll push those revert commits in separate follow-ups so this policy PR stays scoped to the policy itself.

## Test plan

- [ ] AGENTS.md change is the only file modified
- [ ] Once merged, next PR opened should NOT touch version files
- [ ] Release flow: cut a v0.6.22 release tag via a dedicated `bump version` commit on main, AFTER #26 and #27 merge clean (without version bumps).