### PR TITLE
skill: pin report_title / report_description as mandatory at Phase 4 validation

### DIFF
--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -1468,7 +1468,9 @@ Phase 4 is the terminal phase. It picks widgets, performs FINAL JSON-shape valid
 ### Process
 
 1. **Pick widgets via `tools/widget_builder.md`.** Inject `REPORT_TYPE`, `FILTERSET`, `COLUMNS`, `ROUTING_METADATA`, and the matching widget schema (`references/intelligence_widget_schema.json` for types 1/2/3; `references/sponsorship_widget_schema.json` for type 8). The builder emits `{ widgets, histogram_bucket_size, _widget_metadata }`. **The selection rule is: emit only widgets that add value to the user's original prompt.** A widget earns its slot if it answers a question the user implicitly cares about (intent), surfaces a metric tied to a filter the user named (niche), or shows a trend over the date scope they specified. Don't pad to hit 6 — emit fewer (down to 4) if the extras don't answer something. The builder handles type-8 axis branching and intent-driven swaps per the schema's `_tl_intent_overrides`.
-2. **FINAL JSON-shape validation pass.** Verify the composed config:
+2. **Generate `report_title` and `report_description`** from the FilterSet + the user's original NL request. Title ≤ 60 chars; description 1–3 sentences summarizing intent + key filters. **Do this BEFORE step 3's validation pass** — both fields are mandatory on save, so the validation in step 3 needs to see them populated.
+3. **FINAL JSON-shape validation pass.** Verify the composed config:
+   - **`report_title` is a non-empty string ≤ 60 chars AND `report_description` is a non-empty 1–3 sentences.** Both fields are **MANDATORY** on `tl reports create` — the CLI rejects with HTTP 400 `Missing required field: report_title` (or `report_description`) if either is missing. If step 2 (title/description generation) hasn't run yet, run it FIRST, then come back to this check. Verbatim regression marker (real run, LATAM cooking 2026-05-11): saved config omitted `report_title`; first `tl reports create --config-file <path> --yes` returned `Error (400): Missing required field: report_title` and the agent had to edit the transport file and retry. **Fail closed at this validation step rather than discovering the missing field at save time** — a save-side 400 wastes a CLI round-trip and a credit charge.
    - Every field in `filterset` exists in the schema and matches its declared type.
    - Every column in `columns` is in the type's column file.
    - Every aggregator in `widgets` is in the matching catalog (intelligence for 1/2/3, sponsorship for 8).
@@ -1477,7 +1479,6 @@ Phase 4 is the terminal phase. It picks widgets, performs FINAL JSON-shape valid
    - When `cross_references` is present, `report_type ∈ {1, 3}`.
    - When `filters_json.similar_to_channels` is present, no overlapping `keywords` / `topics` fields.
    - `type = 2` (DYNAMIC) and `report_type ∈ {1, 2, 3, 8}` — Campaign-model contract for the API endpoint.
-3. **Generate `report_title` and `report_description`** from the FilterSet + the user's original NL request. Title ≤ 60 chars; description 1–3 sentences summarizing intent + key filters.
 4. **Compose key takeaway insights** — see "Takeaway-composition rules" below. These are the headline observations the user reads in the Phase 4 message. The `_validation` block from Phase 2 carries through here — narrow-result notes, sample_judge reasoning, and validation_concerns are all surfaced as takeaways.
 5. **Emit the final deliverable.**
 

--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -321,11 +321,16 @@ USER_QUERY
 │     • Type-8: count_sponsorships, sum_price (axis branches on          │
 │       publish_status — send_date for proposals, purchase_date for sold)│
 │     • histogram_bucket_size set per date range                         │
+│     • Generate report_title + report_description from final config     │
+│       (must happen BEFORE validation — both fields are mandatory       │
+│        on save and the validation step below checks for them)          │
 │     • PERFORM FINAL JSON-SHAPE VALIDATION of the campaign config:      │
 │         – All Phase 2 + Phase 3 + Phase 4 outputs compose validly      │
 │         – API-contract pre-check (type=2 DYNAMIC, valid report_type,   │
-│           non-empty columns, sort references an emitted column)        │
-│     • Generate report_title + report_description from final config     │
+│           non-empty columns, sort references an emitted column,        │
+│           report_title ≤60 chars non-empty, report_description         │
+│           1–3 sentences non-empty — both mandatory on save; CLI        │
+│           rejects with HTTP 400 if either is missing)                  │
 │     • Compose key takeaway insights                                    │
 │                                                                          │
 │   ↘ FOLLOW-UP TRIGGERS:                                                 │


### PR DESCRIPTION
**Skill content fix** — pin `report_title` / `report_description` as mandatory at Phase 4 final-validation. No version bump.

## Why

A LATAM-cooking run on v0.6.22 (post-#29) shipped a saved-config payload without `report_title`. First `tl reports create --config-file <path> --yes` returned:

```
Error (400): Missing required field: report_title
```

The agent recovered by editing the transport file and retrying — the recovery path worked, but the save-side 400 is wasted work that should have been caught at Phase 4's **final JSON-shape validation pass**, one step earlier.

Root cause: Phase 4's process had `report_title` / `report_description` generation as **step 3**, AFTER the validation pass in step 2. The validation list checked filterset, columns, widgets, sort, axes, cross_references, etc. — but never checked that the title/description were populated, because they were generated AFTER validation ran.

## What this PR fixes

Two minimal edits to Phase 4's process in `SKILL.md`:

| | Before | After |
|---|---|---|
| **Step order** | step 2 = validation, step 3 = generate title/description | **step 2 = generate title/description, step 3 = validation** (so validation can see the fields it needs to check) |
| **Validation list** | No mention of `report_title` / `report_description` | New mandatory-presence bullet at the top of the validation list, pinned to the verbatim 400 regression marker (LATAM cooking 2026-05-11): *`Error (400): Missing required field: report_title`* |

The new bullet:

> **`report_title` is a non-empty string ≤ 60 chars AND `report_description` is a non-empty 1–3 sentences.** Both fields are **MANDATORY** on `tl reports create` — the CLI rejects with HTTP 400 `Missing required field: report_title` (or `report_description`) if either is missing. ... **Fail closed at this validation step rather than discovering the missing field at save time** — a save-side 400 wastes a CLI round-trip and a credit charge.

User-facing language stays plain English. The regression marker is internal SKILL.md prose (not narrated to users).

## Why no version bump

Per maintainer direction. This is a single-line skill content fix with no behavioral surface change visible from outside the agent's tool calls. The v0.6.22 → v0.6.23 boundary is tracked separately (PR #28 covers the bump-on-main policy).

## Test plan

After merge + Claude Code restart, re-run any save-mode prompt that would have hit the bug:

- [ ] *"save a report of LATAM cooking channels with 250K+ subscribers"* — `tl reports create` succeeds on the first attempt (no 400, no edit-and-retry).
- [ ] Any other save-mode prompt that previously round-tripped through a missing-title 400 now succeeds first try.
- [ ] On the rare path where title/description generation actually fails (shouldn't happen, but defense in depth): Phase 4 validation surfaces the issue as a follow-up question rather than letting the save-side 400 happen.

## Out of scope

- Other potential missing-required-field 400s on the save endpoint (if any). The validation list now has a precedent for pinning these as they're found — current PR covers the one regression we've actually observed.
- The "credit charge wasted on the 400 round-trip" behavior is a separate concern on the CLI side; the skill fix here prevents the round-trip from happening on the typical path, but doesn't change CLI billing semantics.
