### PR TITLE
v0.6.24: bump version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.23"
+version = "0.6.24"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.23"
+__version__ = "0.6.24"


### PR DESCRIPTION
Captures the v0.6.23 → v0.6.24 release boundary, carrying [PR #31](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/31) (canonical topics-table fetch pin + generic-rewrite of regression markers) into a tagged release.

## What this PR contains

Three-file version bump, no other changes:

| File | Before | After |
|---|---|---|
| `pyproject.toml` | `version = "0.6.23"` | `version = "0.6.24"` |
| `.claude-plugin/plugin.json` | `"version": "0.6.23"` | `"version": "0.6.24"` |
| `src/tl_cli/__init__.py` | `__version__ = "0.6.23"` | `__version__ = "0.6.24"` |

## What v0.6.24 ships

From PR #31:

- **Canonical topics-table fetch pinned** in the schema reference (`tl/references/postgres-schema.md`) — single source of truth for the SQL command + the column catalogue + the regression markers.
- **Topic-fetch behaviour rules** at the agent consumption point (`tools/topic_matcher.md` + SKILL.md T1): no name-pattern `WHERE`, no `information_schema.columns` inspection, no retry-with-broader.
- **Empty-fetch ≠ off-taxonomy** distinction: a zero-row result from the canonical (no-WHERE) fetch is a data-plane failure, NOT off-taxonomy. Agents must surface the failure rather than silently fall through to keyword_research.
- **Regression markers generalised** — no dated/named specific runs in the new prompt text; anti-pattern shapes only.

## Stack status

| | State |
|---|---|
| v0.6.21 | ✅ Released (PR #25 — preview-first defaults + 12 cited regressions) |
| v0.6.22 | ✅ Released (bump-only) |
| v0.6.23 | ✅ Released (PR #29 speed-up + Windows install fix) |
| **v0.6.24 (this PR)** | 🟡 Open — bump for PR #31 (topics-table canonical fetch) |

Once merged, cut the v0.6.24 release tag.