### PR TITLE
v0.6.24: bump version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.23"
+version = "0.6.24"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.23"
+__version__ = "0.6.24"


### PR DESCRIPTION
Three-file version bump for v0.6.24 — captures the v0.6.23 → v0.6.24 release boundary carrying [PR #31](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/31) (canonical topics-table fetch pin + generic-rewrite of regression markers) into a tagged release.

Note: this is a re-open of [#32](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/32). The previous PR's head branch was auto-deleted on close, so `gh pr reopen` returned a GraphQL error (can't reopen without the head branch). Branch + commit are identical (`66fcd78`); same diff:

| File | Before | After |
|---|---|---|
| `pyproject.toml` | `version = "0.6.23"` | `version = "0.6.24"` |
| `.claude-plugin/plugin.json` | `"version": "0.6.23"` | `"version": "0.6.24"` |
| `src/tl_cli/__init__.py` | `__version__ = "0.6.23"` | `__version__ = "0.6.24"` |

## Stack status

| | State |
|---|---|
| v0.6.21 | ✅ Released (PR #25) |
| v0.6.22 | ✅ Released (bump-only) |
| v0.6.23 | ✅ Released (PR #29 + Windows install fix) |
| **v0.6.24 (this PR)** | 🟡 Open — bump for PR #31 (topics-table canonical fetch + generic rewrite) |

Once merged, cut the v0.6.24 release tag.