### PR TITLE
Add tl credits commands and signup-on-first-login

### DIFF
--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -92,7 +92,7 @@ Other key concepts:
   - **`purchase_date`** — when the sponsorship was purchased (i.e. when the deal was made); These make up bookings.
   - **`send_date`** — the date the video is/was expected to be published (scheduled)
   - **`publish_date`** — the date the video was actually published; These make up live ads.
-- **Credits** — every data query costs credits; use `tl describe` to see rates
+- **Credits** — every data query costs credits; use `tl describe` to see rates. Top up with `tl credits buy --amount-usd N` (free; opens a browser checkout). New accounts get a starter balance on first `tl auth login`; the rate is shown by `tl credits pricing`.
 
 Users see data scoped by their organization and plan:
 - **Media buyers** see sponsorships where their org is the brand. They see `price` but never `cost`.
@@ -345,7 +345,10 @@ tl schema pg <table>                   # PostgreSQL schema for a SINGLE table (f
 tl schema fb                           # Live Firebolt tables and column types for `tl db fb` (free) — both tables
 tl schema fb <table>                   # Firebolt schema for a SINGLE table (free) — `article_metrics` or `channel_metrics`
 tl schema es                           # Elasticsearch document shape for `tl db es` (free)
-tl balance --json                      # Credit balance (free)
+tl balance --json                      # Credit balance + recent usage (free)
+tl credits pricing                     # Current usd-per-credit rate (free, no auth)
+tl credits buy --amount-usd 10         # Start a top-up; opens browser checkout (free)
+tl credits history                     # Recent top-ups for the caller's org (free)
 tl whoami                              # Current user, org, brands (free)
 tl auth status                         # Auth check (free)
 tl changelog                           # Release notes — current version, or current..latest if behind (free)

--- a/src/tl_cli/auth/commands.py
+++ b/src/tl_cli/auth/commands.py
@@ -4,6 +4,7 @@ import typer
 from rich.console import Console
 from rich.prompt import Prompt
 
+from tl_cli.auth.finalize import finalize_signup
 from tl_cli.auth.login import login_browser, login_device_code
 from tl_cli.auth.token_store import clear_tokens, load_tokens
 
@@ -13,7 +14,12 @@ console = Console(stderr=True)
 
 @app.command("login", help="Log in to ThoughtLeaders.")
 def login_cmd() -> None:
-    """Log in to ThoughtLeaders."""
+    """Log in to ThoughtLeaders.
+
+    After Auth0 returns, the CLI calls the server's finalize endpoint.
+    First-time users are prompted for a persona (Media Buyer or Creator)
+    and the account + starter credits are created on the server side.
+    """
     console.print("[bold]How would you like to authenticate?[/bold]")
     console.print("  [cyan]1[/cyan] — Browser on this machine (default)")
     console.print("  [cyan]2[/cyan] — Device code (use a browser on another device)")
@@ -24,6 +30,8 @@ def login_cmd() -> None:
         login_device_code()
     else:
         login_browser()
+
+    finalize_signup()
 
 
 @app.command("logout")

--- a/src/tl_cli/auth/finalize.py
+++ b/src/tl_cli/auth/finalize.py
@@ -37,6 +37,10 @@ def finalize_signup() -> None:
         except ApiError as exc:
             if exc.status_code == 400 and isinstance(exc.raw, dict) and exc.raw.get("code") == "persona_required":
                 result = _prompt_and_finalize(client, exc.raw.get("allowed_personas") or [])
+            elif exc.status_code == 404:
+                # Server predates this endpoint — silently skip; legacy
+                # accounts already exist and don't need provisioning.
+                return
             else:
                 console.print(f"[yellow]Could not finalize signup: {exc.detail}[/yellow]")
                 return

--- a/src/tl_cli/auth/finalize.py
+++ b/src/tl_cli/auth/finalize.py
@@ -1,0 +1,84 @@
+"""Server-side signup finalize, called once per login.
+
+After Auth0 returns a valid token the CLI asks the server whether an
+account exists for the email. If yes, this is a no-op. If no, the CLI
+prompts for a persona (Media Buyer or Creator) and POSTs it back; the
+server creates the User, Organization, Profile and CreditAccount.
+
+Errors here never abort login — the user can always retry the prompt
+on the next call. We do print a clear message so it's obvious whether
+the account is fully set up.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.prompt import Prompt
+
+from tl_cli.client.errors import ApiError
+from tl_cli.client.http import get_client
+
+console = Console(stderr=True)
+
+PERSONA_LABEL_TO_KEY = {
+    "Media Buyer": "media_buyer",
+    "Creator": "creator",
+}
+
+
+def finalize_signup() -> None:
+    """POST /auth/finalize, prompting for persona if the server asks for one."""
+    client = get_client()
+    try:
+        # First call: no body. Server tells us whether persona is required.
+        try:
+            result = client.post("/auth/finalize", {})
+        except ApiError as exc:
+            if exc.status_code == 400 and isinstance(exc.raw, dict) and exc.raw.get("code") == "persona_required":
+                result = _prompt_and_finalize(client, exc.raw.get("allowed_personas") or [])
+            else:
+                console.print(f"[yellow]Could not finalize signup: {exc.detail}[/yellow]")
+                return
+
+        if result.get("created"):
+            org = result.get("organization", {})
+            console.print(
+                f"[green]Account created for {org.get('name', 'your organization')}.[/green] "
+                "Run [bold]tl balance[/bold] to see your starter credits."
+            )
+    finally:
+        client.close()
+
+
+def _prompt_and_finalize(client, allowed: list[str]) -> dict:
+    """Prompt the user for a persona, then retry /auth/finalize."""
+    console.print()
+    console.print("[bold]Welcome to ThoughtLeaders![/bold] We need one more detail to set up your account.")
+    console.print("  [cyan]1[/cyan] — Media Buyer (brands and agencies buying sponsorships)")
+    console.print("  [cyan]2[/cyan] — Creator (channels selling sponsorships)")
+
+    persona_key: str | None = None
+    while persona_key is None:
+        choice = Prompt.ask("I am a", choices=["1", "2"], default="1", console=console)
+        candidate = "media_buyer" if choice == "1" else "creator"
+        if allowed and candidate not in allowed:
+            console.print(f"[yellow]Server rejects persona '{candidate}'. Allowed: {', '.join(allowed)}.[/yellow]")
+            continue
+        persona_key = candidate
+
+    org_name = Prompt.ask(
+        "Organization name (optional, leave blank to use your email)",
+        default="",
+        console=console,
+    ).strip()
+
+    body = {"persona": persona_key}
+    if org_name:
+        body["organization_name"] = org_name
+
+    try:
+        return client.post("/auth/finalize", body)
+    except ApiError as exc:
+        console.print(f"[red]Signup failed:[/red] {exc.detail}")
+        raise typer.Exit(1)

--- a/src/tl_cli/client/errors.py
+++ b/src/tl_cli/client/errors.py
@@ -46,7 +46,8 @@ def handle_api_error(error: ApiError) -> None:
         sys.exit(2)
     elif error.status_code == 402:
         err.print("[red]Insufficient credits.[/red]")
-        err.print("Deposit more at: https://app.thoughtleaders.io/settings/billing")
+        err.print("Top up with: [bold]tl credits buy --amount-usd 10[/bold]")
+        err.print("Or visit: https://app.thoughtleaders.io/billing/cli")
         _print_debug(error)
         sys.exit(4)
     elif error.status_code == 403:

--- a/src/tl_cli/commands/balance.py
+++ b/src/tl_cli/commands/balance.py
@@ -46,6 +46,19 @@ def balance(
         if allow_overage:
             console.print("[dim]Overage: enabled[/dim]")
 
+        # Top-up hint when running low. Threshold matches the hook warning
+        # that nudges the user before they hit 0.
+        try:
+            balance_decimal = float(balance_val)
+        except (TypeError, ValueError):
+            balance_decimal = None
+        if balance_decimal is not None and balance_decimal < 500:
+            console.print(
+                "[yellow]Running low.[/yellow] Top up with: "
+                "[bold]tl credits buy --amount-usd 10[/bold] "
+                "(or https://app.thoughtleaders.io/billing/cli)"
+            )
+
         recent = data.get("recent_usage", [])
         if recent:
             table = Table(title="Recent Usage")

--- a/src/tl_cli/commands/credits.py
+++ b/src/tl_cli/commands/credits.py
@@ -1,0 +1,184 @@
+"""tl credits — buy credits and view top-up history.
+
+`tl credits buy --amount-usd N` calls the server to start a top-up,
+opens the resulting web checkout URL in the user's browser, and polls
+the balance until it changes (or the user gives up).
+
+`tl credits history` lists recent top-ups for the caller's org.
+
+`tl credits pricing` shows the current usd-per-credit rate. Use this to
+sanity-check what `--amount-usd N` will buy before paying.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import webbrowser
+from decimal import Decimal, InvalidOperation
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from tl_cli.client.errors import ApiError, handle_api_error
+from tl_cli.client.http import get_client
+from tl_cli.output.formatter import detect_format
+
+app = typer.Typer(help="Buy credits and view top-up history (free)")
+console = Console()
+err = Console(stderr=True)
+
+
+@app.command("pricing")
+def pricing_cmd(
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+) -> None:
+    """Show the credit-to-USD rate, minimum purchase, and starter balance.
+
+    Free — no authentication required.
+    """
+    client = get_client()
+    try:
+        data = client.get("/pricing")
+    except ApiError as e:
+        handle_api_error(e)
+        return
+    finally:
+        client.close()
+
+    if json_output:
+        print(json.dumps(data, indent=2, default=str))
+        return
+
+    console.print(f"\n[bold]Rate:[/bold] ${data['usd_per_credit']} per credit ({data.get('currency', 'USD')})")
+    console.print(f"[bold]Minimum top-up:[/bold] ${data['min_purchase_usd']}")
+    console.print(f"[bold]Starter balance:[/bold] {data['starter_balance']} credits")
+
+
+@app.command("buy")
+def buy_cmd(
+    amount_usd: str = typer.Option(..., "--amount-usd", help="Amount to top up, in USD."),
+    no_browser: bool = typer.Option(False, "--no-browser", help="Don't open a browser, just print the checkout URL."),
+    poll: bool = typer.Option(True, "--poll/--no-poll", help="Poll balance after opening the checkout page."),
+) -> None:
+    """Start a credit top-up.
+
+    Calls the server to create a pending purchase, opens the web checkout
+    URL, and (by default) polls `tl balance` until the credits land or you
+    Ctrl-C out.
+    """
+    try:
+        Decimal(amount_usd)
+    except (InvalidOperation, ValueError):
+        err.print(f"[red]Invalid amount:[/red] {amount_usd}")
+        raise typer.Exit(1)
+
+    client = get_client()
+    try:
+        try:
+            initial = client.get("/balance")
+            initial_balance = Decimal(str(initial.get("balance", 0)))
+        except ApiError:
+            # Pricing fetch may work even if balance fails; still attempt the purchase.
+            initial_balance = None
+
+        try:
+            result = client.post("/top-up", {"usd_amount": amount_usd})
+        except ApiError as e:
+            handle_api_error(e)
+            return
+    finally:
+        client.close()
+
+    checkout_url = result.get("checkout_url")
+    credits = result.get("credits")
+    console.print(
+        f"\n[bold]Started top-up:[/bold] ${result['usd_amount']} → {credits} credits"
+    )
+    console.print(f"Checkout: {checkout_url}")
+
+    if checkout_url and not no_browser:
+        try:
+            webbrowser.open(checkout_url)
+        except Exception:
+            pass
+
+    if not poll or initial_balance is None:
+        console.print("[dim]Run `tl balance` to confirm once payment completes.[/dim]")
+        return
+
+    _poll_for_credit(initial_balance, expected_increment=Decimal(str(credits)))
+
+
+def _poll_for_credit(initial_balance: Decimal, expected_increment: Decimal) -> None:
+    """Poll the balance endpoint until it goes up. Bounded so the CLI
+    eventually returns to the prompt instead of hanging forever.
+    """
+    console.print("[dim]Waiting for payment confirmation (up to 10 minutes; Ctrl-C to stop)…[/dim]")
+    deadline = time.time() + 600
+    last_balance = initial_balance
+    try:
+        while time.time() < deadline:
+            time.sleep(5)
+            client = get_client()
+            try:
+                data = client.get("/balance")
+            except ApiError:
+                client.close()
+                continue
+            client.close()
+            new_balance = Decimal(str(data.get("balance", 0)))
+            if new_balance >= initial_balance + expected_increment:
+                console.print(f"[green]Payment confirmed.[/green] New balance: [cyan]{new_balance}[/cyan] credits")
+                return
+            if new_balance != last_balance:
+                console.print(f"[dim]Balance updated: {new_balance} credits[/dim]")
+                last_balance = new_balance
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Stopped polling.[/yellow] Run `tl balance` later to check.")
+        return
+    console.print("[yellow]Timed out waiting for payment.[/yellow] Run `tl balance` later to check.")
+
+
+@app.command("history")
+def history_cmd(
+    limit: int = typer.Option(25, "--limit", help="Max rows to show"),
+    offset: int = typer.Option(0, "--offset", help="Offset for pagination"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+) -> None:
+    """Show recent credit top-ups for your organization (free)."""
+    fmt = detect_format(json_output, False, False, False)
+    client = get_client()
+    try:
+        data = client.get("/credit-purchases", params={"limit": limit, "offset": offset})
+    except ApiError as e:
+        handle_api_error(e)
+        return
+    finally:
+        client.close()
+
+    if fmt == "json":
+        print(json.dumps(data, indent=2, default=str))
+        return
+
+    rows = data.get("results", [])
+    if not rows:
+        console.print("[dim]No credit purchases yet. Run `tl credits buy --amount-usd N`.[/dim]")
+        return
+
+    table = Table(title=f"Credit purchases ({data.get('total', len(rows))} total)")
+    table.add_column("Date")
+    table.add_column("USD", justify="right")
+    table.add_column("Credits", justify="right")
+    table.add_column("Status")
+    table.add_column("Invoice")
+    for row in rows:
+        table.add_row(
+            row.get("created_at", "")[:19].replace("T", " "),
+            row.get("usd_amount", ""),
+            row.get("credits", ""),
+            row.get("status", ""),
+            row.get("green_invoice_document_id") or "—",
+        )
+    console.print(table)

--- a/src/tl_cli/commands/whoami.py
+++ b/src/tl_cli/commands/whoami.py
@@ -61,6 +61,10 @@ def _render_whoami(data: dict) -> None:
     if org.get("is_managed_services"):
         org_lines.append("Managed services", style="magenta")
         org_lines.append("\n")
+    if "credits_balance" in org:
+        org_lines.append("Credits: ", style="dim")
+        org_lines.append(f"{org['credits_balance']:g}", style="cyan")
+        org_lines.append("\n")
     start = org.get("contract_start_date")
     end = org.get("contract_end_date")
     if start or end:
@@ -136,6 +140,8 @@ def _render_whoami_md(data: dict) -> None:
         print(f"- **Plan:** {plan}")
     if org.get("is_managed_services"):
         print("- **Managed services:** yes")
+    if "credits_balance" in org:
+        print(f"- **Credits:** {org['credits_balance']:g}")
     start = org.get("contract_start_date")
     end = org.get("contract_end_date")
     if start or end:

--- a/src/tl_cli/commands/whoami.py
+++ b/src/tl_cli/commands/whoami.py
@@ -26,10 +26,13 @@ def _render_whoami(data: dict) -> None:
 
     # --- User ---
     name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
+    email = user.get("email", "")
     title = Text()
-    title.append(name or user.get("email", ""), style="bold cyan")
-    if name:
-        title.append(f"  {user.get('email', '')}", style="dim")
+    if name and email:
+        title.append(f'"{name}"', style="bold cyan")
+        title.append(f" <{email}>", style="dim")
+    else:
+        title.append(f"<{email}>" if email else name, style="bold cyan")
 
     flags = profile.get("flags", [])
     persona = profile.get("persona")
@@ -122,9 +125,12 @@ def _render_whoami_md(data: dict) -> None:
     brands = data.get("brands", [])
 
     name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
-    print(f"# {name or user.get('email', '')}\n")
-    if name:
-        print(f"- **Email:** {user.get('email', '')}")
+    email = user.get("email", "")
+    if name and email:
+        header = f'"{name}" <{email}>'
+    else:
+        header = f"<{email}>" if email else name
+    print(f"# {header}\n")
     persona = profile.get("persona")
     if persona:
         print(f"- **Persona:** {persona}")

--- a/src/tl_cli/main.py
+++ b/src/tl_cli/main.py
@@ -17,6 +17,7 @@ from tl_cli.commands.balance import app as balance_app
 from tl_cli.commands.changelog import changelog_command
 from tl_cli.commands.brands import app as brands_app
 from tl_cli.commands.bulk_import import bulk_import_command
+from tl_cli.commands.credits import app as credits_app
 from tl_cli.commands.channels import app as channels_app
 from tl_cli.commands.db import app as db_app
 from tl_cli.commands.deals import app as deals_app
@@ -104,6 +105,7 @@ app.add_typer(db_app, name="db")
 app.add_typer(describe_app, name="describe")
 app.add_typer(schema_app, name="schema")
 app.add_typer(balance_app, name="balance")
+app.add_typer(credits_app, name="credits")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(whoami_app, name="whoami")
 


### PR DESCRIPTION
## Summary

- New `tl credits` group: `pricing` (free, shows usd-per-credit rate and minimum top-up), `buy --amount-usd N` (creates a pending purchase, opens the web checkout, polls `tl balance` until credits land), `history` (paginated recent top-ups).
- `tl auth login` now calls the server's `/auth/finalize` endpoint after PKCE. First-time users are prompted for a persona (Media Buyer or Creator) and the server provisions the account with a starter balance — no separate signup step.
- The 402 (insufficient credits) error now points the user at `tl credits buy` and the web billing URL.
- `tl balance` adds a top-up hint when the balance drops below 500 credits.
- `skills/tl/SKILL.md` picks up the new commands under "Discovery & system" and the starter-balance + top-up story under the credits terminology.

Depends on the server-side endpoints landing in ThoughtLeaders-io/thoughtleaders#3999.

## Test plan

- [x] `python3 -c "from tl_cli.main import app"` — module loads, `credits` group is registered
- [ ] `tl credits pricing` against staging — returns the configured rate
- [ ] `tl auth login` as a brand-new email — persona prompt appears, server creates the account, `tl balance` shows the starter balance
- [ ] `tl credits buy --amount-usd 10` — opens browser, pays through BlueSnap sandbox, `tl balance` reflects the new credits after IPN settles
- [ ] `tl credits history` shows the just-completed purchase with the GreenInvoice document ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)