### PR TITLE
v0.6.25: bump version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.24"
+version = "0.6.25"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.24"
+__version__ = "0.6.25"


### PR DESCRIPTION
Ships the `tl bulk-import` command and skill that landed in #37.

Routine version bump across the three canonical files:
- `pyproject.toml`
- `.claude-plugin/plugin.json`
- `src/tl_cli/__init__.py`

No behaviour change beyond what #37 already merged.