### PR TITLE
Surface a clear failure message when auto-upgrade fails

### DIFF
--- a/src/tl_cli/self_update.py
+++ b/src/tl_cli/self_update.py
@@ -115,12 +115,52 @@ def _run_upgrade(method: str, latest: str) -> None:
         f"[tl-cli] upgrading {__version__} → {latest} via {method}…",
         file=sys.stderr,
     )
+    # Capture output so a noisy traceback from a broken upgrader (seen on
+    # Windows pipx shims that lose track of their own module) doesn't get
+    # dumped into the user's shell — we surface it deliberately on failure
+    # alongside an actionable next-step message.
     try:
-        result = subprocess.run(cmd, check=False, timeout=60)
-    except (OSError, subprocess.TimeoutExpired):
+        result = subprocess.run(cmd, check=False, timeout=60, capture_output=True, text=True)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(
+            f"[tl-cli] could not run {method}: {exc}\n"
+            f"[tl-cli] upgrade manually with:\n  {' '.join(cmd)}",
+            file=sys.stderr,
+        )
         return
     if result.returncode == 0:
         _resync_integrations()
+        return
+    _report_upgrade_failure(method, cmd, result)
+
+
+def _report_upgrade_failure(method: str, cmd: list[str], result: subprocess.CompletedProcess) -> None:
+    """Print a user-friendly failure message after a non-zero upgrader exit.
+
+    On Windows in particular, `pipx.exe` can be a broken shim that errors
+    with `ModuleNotFoundError: No module named 'pipx'`. We detect that and
+    give a targeted hint instead of just echoing the traceback.
+    """
+    combined_err = (result.stderr or '') + (result.stdout or '')
+    print(
+        f"[tl-cli] automatic upgrade failed (exit {result.returncode}).",
+        file=sys.stderr,
+    )
+    if "No module named 'pipx'" in combined_err:
+        print(
+            "[tl-cli] Your pipx install appears broken (its launcher can't find the pipx module).\n"
+            "[tl-cli] Reinstall pipx from your system Python, then rerun the upgrade.\n"
+            "[tl-cli] Or switch to uv:  uv tool install --force " + cmd[-1],
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"[tl-cli] To upgrade manually, run:\n  {' '.join(cmd)}",
+            file=sys.stderr,
+        )
+    if combined_err.strip():
+        print("[tl-cli] Upgrader output:", file=sys.stderr)
+        sys.stderr.write(combined_err if combined_err.endswith('\n') else combined_err + '\n')
 
 
 def _resync_integrations() -> None:


### PR DESCRIPTION
## Summary

Reported failure on Windows:
\`\`\`
[tl-cli] upgrading 0.6.24 → 0.6.25 via pipx…
…
ModuleNotFoundError: No module named 'pipx'
\`\`\`
The upgrader subprocess crashed, returned non-zero, and `_run_upgrade` silently did nothing — the user saw a half-printed status line and a traceback, with no idea what to do next.

This PR:

- Captures the upgrader's stdout/stderr (so a noisy traceback doesn't dump straight into the user's shell on every invocation).
- On non-zero exit, prints a clean `[tl-cli] automatic upgrade failed` line with the exact command to run manually, then echoes the captured output.
- Specifically detects the Windows pipx-shim breakage (`ModuleNotFoundError: No module named 'pipx'`) and recommends either reinstalling pipx from the system Python or switching to `uv tool install --force git+…@vX.Y.Z` instead.

## Test plan

- [x] Module imports clean
- [ ] Force a failure on Linux (e.g. break PATH so `pipx` is missing) → user sees the "automatic upgrade failed" line + manual command
- [ ] Repro on the affected Windows install → user sees the targeted "pipx install appears broken" hint instead of the bare traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)