### PR TITLE
v0.6.26: bump version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.25"
+version = "0.6.26"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.25"
+__version__ = "0.6.26"


### PR DESCRIPTION
Ships the `tl-import` skill rename + rich-envelope consumption from [#42](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/42).

Routine three-file bump:
- `pyproject.toml`
- `.claude-plugin/plugin.json`
- `src/tl_cli/__init__.py`

**Merge order:** #42 first, then this.