### PR TITLE
tl setup: sweep orphaned skills from previous installs

### DIFF
--- a/src/tl_cli/commands/setup.py
+++ b/src/tl_cli/commands/setup.py
@@ -100,34 +100,91 @@ def check_plugin_version() -> list[str]:
     return warnings
 
 
-def _install_standalone_skills(plugin_root: Path) -> int:
+SKILLS_MANIFEST_FILENAME = ".tl-cli-skills-manifest"
+
+
+def _read_skills_manifest(target_dir: Path) -> set[str]:
+    """Return the set of skill directory names this plugin installed previously.
+
+    Empty set if no manifest exists yet (first install or pre-manifest install).
+    """
+    manifest = target_dir / SKILLS_MANIFEST_FILENAME
+    if not manifest.exists():
+        return set()
+    try:
+        return {line.strip() for line in manifest.read_text().splitlines() if line.strip()}
+    except OSError:
+        return set()
+
+
+def _write_skills_manifest(target_dir: Path, names: set[str]) -> None:
+    """Persist which skill directory names this plugin owns in target_dir."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    manifest = target_dir / SKILLS_MANIFEST_FILENAME
+    manifest.write_text("\n".join(sorted(names)) + "\n")
+
+
+def _sync_plugin_skills(plugin_root: Path, target_dir: Path) -> tuple[int, list[str]]:
+    """Install all source skills into target_dir; sweep orphans from prior installs.
+
+    The manifest at `target_dir/.tl-cli-skills-manifest` records the directory
+    names this plugin installed in the previous run. On the next run, any name
+    present in the previous manifest but missing from the current source is
+    removed — that's how a renamed or deleted skill stops triggering for users
+    who installed via `tl setup`. Skill directories not owned by this plugin
+    (other tools, hand-written user skills) are never touched.
+
+    Returns (installed_count, swept_skill_names).
+    """
+    skills_src = plugin_root / "skills"
+    if not skills_src.is_dir():
+        return 0, []
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    installed: set[str] = set()
+    for skill_dir in skills_src.iterdir():
+        if skill_dir.is_dir() and (skill_dir / "SKILL.md").is_file():
+            dst = target_dir / skill_dir.name
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(skill_dir, dst)
+            installed.add(skill_dir.name)
+
+    previous = _read_skills_manifest(target_dir)
+    swept: list[str] = []
+    for name in sorted(previous - installed):
+        orphan = target_dir / name
+        if orphan.is_dir():
+            shutil.rmtree(orphan)
+            swept.append(name)
+
+    if installed:
+        _write_skills_manifest(target_dir, installed)
+
+    return len(installed), swept
+
+
+def _install_standalone_skills(plugin_root: Path) -> tuple[int, list[str]]:
     """Copy skills and commands to ~/.claude/ for non-namespaced invocation.
 
-    Returns the number of items installed.
+    Returns (item_count, swept_skill_names) where item_count covers both skills
+    and commands and swept_skill_names lists skill dirs removed because they
+    were installed by a previous version of this plugin and have since been
+    renamed/deleted in the source.
     """
-    count = 0
-
-    # Skills: skills/<name>/SKILL.md → ~/.claude/skills/<name>/SKILL.md
-    skills_src = plugin_root / "skills"
-    if skills_src.is_dir():
-        for skill_dir in skills_src.iterdir():
-            if skill_dir.is_dir() and (skill_dir / "SKILL.md").is_file():
-                dst = CLAUDE_SKILLS_DIR / skill_dir.name
-                if dst.exists():
-                    shutil.rmtree(dst)
-                shutil.copytree(skill_dir, dst)
-                count += 1
+    skill_count, swept = _sync_plugin_skills(plugin_root, CLAUDE_SKILLS_DIR)
 
     # Commands: commands/<name>.md → ~/.claude/commands/<name>.md
+    command_count = 0
     commands_src = plugin_root / "commands"
     if commands_src.is_dir():
         CLAUDE_COMMANDS_DIR.mkdir(parents=True, exist_ok=True)
         for cmd_file in commands_src.glob("*.md"):
             dst = CLAUDE_COMMANDS_DIR / cmd_file.name
             shutil.copy2(cmd_file, dst)
-            count += 1
+            command_count += 1
 
-    return count
+    return skill_count + command_count, swept
 
 
 def _print_manual_instructions() -> None:
@@ -252,11 +309,13 @@ def setup_claude(
 def _install_standalone_skills_step(plugin_root: Path) -> None:
     """Install standalone skills and print status."""
     console.print("[bold]Installing skills for /tl shortcut...[/bold]")
-    count = _install_standalone_skills(plugin_root)
+    count, swept = _install_standalone_skills(plugin_root)
     if count > 0:
         console.print(f"  [green]✓[/green] Installed {count} skills/commands to ~/.claude/")
     else:
         console.print("  [yellow]![/yellow] No skills found to install")
+    if swept:
+        console.print(f"  [green]✓[/green] Removed {len(swept)} orphaned skill(s) from previous installs: {', '.join(swept)}")
 
 
 def _setup_noninteractive() -> None:
@@ -293,8 +352,9 @@ def _setup_noninteractive() -> None:
         result["plugin_installed"] = False
 
     # Always install standalone skills
-    count = _install_standalone_skills(plugin_root)
+    count, swept = _install_standalone_skills(plugin_root)
     result["standalone_skills_installed"] = count
+    result["orphaned_skills_swept"] = swept
 
     # Write version stamp
     version_dir = CLAUDE_PLUGINS_DIR / "tl-cli"
@@ -308,22 +368,14 @@ def _setup_noninteractive() -> None:
 # --- OpenCode setup ---
 
 
-def _install_opencode_skills(plugin_root: Path) -> int:
+def _install_opencode_skills(plugin_root: Path) -> tuple[int, list[str]]:
     """Copy skills to ~/.config/opencode/skills/ for OpenCode discovery.
 
-    Returns the number of skills installed.
+    Returns (installed_count, swept_skill_names) — same shape and sweep
+    semantics as `_install_standalone_skills`, targeting OpenCode's skills
+    directory.
     """
-    count = 0
-    skills_src = plugin_root / "skills"
-    if skills_src.is_dir():
-        for skill_dir in skills_src.iterdir():
-            if skill_dir.is_dir() and (skill_dir / "SKILL.md").is_file():
-                dst = OPENCODE_SKILLS_DIR / skill_dir.name
-                if dst.exists():
-                    shutil.rmtree(dst)
-                shutil.copytree(skill_dir, dst)
-                count += 1
-    return count
+    return _sync_plugin_skills(plugin_root, OPENCODE_SKILLS_DIR)
 
 
 @app.command("opencode")
@@ -347,10 +399,11 @@ def setup_opencode(
             result["error"] = "Plugin assets not found"
             print(json.dumps(result, indent=2))
             raise SystemExit(1)
-        count = _install_opencode_skills(plugin_root)
+        count, swept = _install_opencode_skills(plugin_root)
         OPENCODE_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
         (OPENCODE_SKILLS_DIR / ".tl-version").write_text(__version__)
         result["skills_installed"] = count
+        result["orphaned_skills_swept"] = swept
         result["status"] = "ok"
         print(json.dumps(result, indent=2))
         return
@@ -379,12 +432,14 @@ def setup_opencode(
 
     # Install skills
     console.print("[bold]Installing skills...[/bold]")
-    count = _install_opencode_skills(plugin_root)
+    count, swept = _install_opencode_skills(plugin_root)
     if count > 0:
         console.print(f"  [green]✓[/green] Installed {count} skill(s) to {OPENCODE_SKILLS_DIR}/")
     else:
         console.print("  [yellow]![/yellow] No skills found to install")
         raise SystemExit(1)
+    if swept:
+        console.print(f"  [green]✓[/green] Removed {len(swept)} orphaned skill(s) from previous installs: {', '.join(swept)}")
 
     # Write version stamp
     OPENCODE_SKILLS_DIR.mkdir(parents=True, exist_ok=True)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,132 @@
+"""Tests for the tl setup skill-sync helper."""
+
+import shutil
+from pathlib import Path
+
+from tl_cli.commands.setup import (
+    SKILLS_MANIFEST_FILENAME,
+    _read_skills_manifest,
+    _sync_plugin_skills,
+)
+
+
+def _make_skill(plugin_root: Path, name: str) -> None:
+    skill_dir = plugin_root / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n# {name}\n")
+
+
+class TestSyncPluginSkills:
+    def test_initial_install(self, tmp_path: Path) -> None:
+        plugin_root = tmp_path / "plugin"
+        target = tmp_path / "target"
+        _make_skill(plugin_root, "foo")
+        _make_skill(plugin_root, "bar")
+
+        count, swept = _sync_plugin_skills(plugin_root, target)
+
+        assert count == 2
+        assert swept == []
+        assert (target / "foo" / "SKILL.md").is_file()
+        assert (target / "bar" / "SKILL.md").is_file()
+        assert _read_skills_manifest(target) == {"foo", "bar"}
+
+    def test_sweeps_renamed_skill(self, tmp_path: Path) -> None:
+        plugin_root = tmp_path / "plugin"
+        target = tmp_path / "target"
+
+        # First install: foo + bar
+        _make_skill(plugin_root, "foo")
+        _make_skill(plugin_root, "bar")
+        _sync_plugin_skills(plugin_root, target)
+        assert (target / "foo" / "SKILL.md").is_file()
+
+        # Rename: foo -> tl-foo in the source
+        shutil.rmtree(plugin_root / "skills" / "foo")
+        _make_skill(plugin_root, "tl-foo")
+
+        count, swept = _sync_plugin_skills(plugin_root, target)
+
+        assert count == 2  # bar + tl-foo
+        assert swept == ["foo"]
+        assert (target / "tl-foo" / "SKILL.md").is_file()
+        assert (target / "bar" / "SKILL.md").is_file()
+        assert not (target / "foo").exists()
+        assert _read_skills_manifest(target) == {"bar", "tl-foo"}
+
+    def test_never_touches_skills_outside_manifest(self, tmp_path: Path) -> None:
+        """Critical invariant: sweep only removes skills this plugin installed.
+
+        A user might install their own skill or a different tool's skill into
+        the same target directory. The sweep must leave those alone.
+        """
+        plugin_root = tmp_path / "plugin"
+        target = tmp_path / "target"
+        _make_skill(plugin_root, "foo")
+        # First install creates the manifest with just {foo}
+        _sync_plugin_skills(plugin_root, target)
+
+        # User drops in their own skill (NOT installed by this plugin)
+        user_skill = target / "user-thing"
+        user_skill.mkdir()
+        (user_skill / "SKILL.md").write_text("user content")
+
+        # Re-run sync — user-thing must survive even though it's not in the
+        # source or the manifest. It wasn't installed by us, so we don't touch it.
+        count, swept = _sync_plugin_skills(plugin_root, target)
+
+        assert count == 1  # only foo from source
+        assert swept == []
+        assert (target / "user-thing" / "SKILL.md").is_file()
+        assert (target / "user-thing" / "SKILL.md").read_text() == "user content"
+
+    def test_no_manifest_on_first_install_is_fine(self, tmp_path: Path) -> None:
+        """If the target dir already has some content from a pre-manifest
+        install, the first run with manifest support won't sweep them — we
+        haven't recorded them as ours yet. This is correct: we only sweep
+        what we know we installed."""
+        plugin_root = tmp_path / "plugin"
+        target = tmp_path / "target"
+        target.mkdir()
+        # Simulate a pre-manifest leftover
+        pre_existing = target / "old-skill"
+        pre_existing.mkdir()
+        (pre_existing / "SKILL.md").write_text("legacy")
+
+        _make_skill(plugin_root, "new-skill")
+        count, swept = _sync_plugin_skills(plugin_root, target)
+
+        # First install — no manifest to compare against, so nothing swept.
+        # `old-skill` survives this run; the *next* re-install (after a rename
+        # in the source) will catch the renamed dir but `old-skill` stays
+        # untouched permanently since we never claimed ownership.
+        assert count == 1
+        assert swept == []
+        assert (target / "old-skill" / "SKILL.md").is_file()
+        assert (target / "new-skill" / "SKILL.md").is_file()
+
+    def test_empty_plugin_source(self, tmp_path: Path) -> None:
+        plugin_root = tmp_path / "plugin"
+        plugin_root.mkdir()
+        target = tmp_path / "target"
+
+        count, swept = _sync_plugin_skills(plugin_root, target)
+
+        assert count == 0
+        assert swept == []
+
+    def test_skill_without_SKILL_md_is_ignored(self, tmp_path: Path) -> None:
+        """Directories under `skills/` without a SKILL.md aren't real skills
+        and shouldn't be copied or tracked."""
+        plugin_root = tmp_path / "plugin"
+        target = tmp_path / "target"
+        (plugin_root / "skills" / "real").mkdir(parents=True)
+        (plugin_root / "skills" / "real" / "SKILL.md").write_text("# real")
+        (plugin_root / "skills" / "not-a-skill").mkdir()  # no SKILL.md
+
+        count, swept = _sync_plugin_skills(plugin_root, target)
+
+        assert count == 1
+        assert swept == []
+        assert (target / "real" / "SKILL.md").is_file()
+        assert not (target / "not-a-skill").exists()


### PR DESCRIPTION
## Summary

When the plugin renames or removes a skill, users who install via \`tl setup claude\` / \`tl setup opencode\` get the new skill copied into \`~/.claude/skills/\` (or \`~/.config/opencode/skills/\`) — but the old directory is left behind. Both trigger on similar natural-language prompts, leading to ambiguous routing.

Concrete case from last week: when \`bulk-import\` was renamed to \`tl-import\` in v0.6.26, users on \`tl setup\` ended up with both \`~/.claude/skills/bulk-import/\` and \`~/.claude/skills/tl-import/\`.

## Fix

Keep a small manifest (\`.tl-cli-skills-manifest\`) in each install target listing the skill directory names this plugin installed in the previous run. On the next run:

1. Install all source skills into the target (same as before).
2. Read the previous manifest.
3. Any name in the previous manifest but **missing from the current source** is removed.
4. Write a fresh manifest listing what's currently installed.

User-installed skills, or skills from other tools, are never touched — the sweep only acts on names this plugin claimed ownership of last time.

## Shared between Claude Code and OpenCode paths

Both \`_install_standalone_skills\` (Claude Code) and \`_install_opencode_skills\` (OpenCode) now delegate to a new \`_sync_plugin_skills(plugin_root, target_dir)\` helper. Their return signatures changed from \`int\` → \`tuple[int, list[str]]\` to surface the swept skill names; both interactive output and JSON output were updated to report them.

## Tests

\`tests/test_setup.py\` covers:

- Initial install populates manifest correctly
- Renamed source skill sweeps the old name on re-install
- User-installed skill at the same target is **never** swept (critical safety invariant)
- First run with no manifest doesn't sweep anything (so pre-existing dirs from older versions survive that one time)
- Empty source directory is a no-op
- Directories under \`skills/\` without a \`SKILL.md\` are ignored

All 6 tests pass locally.

## Migration heads-up

On the **first** run after this lands, no manifest exists yet, so no orphans are swept that one time. The pre-existing \`~/.claude/skills/bulk-import/\` from v0.6.25 won't be removed automatically — users can \`rm -rf\` it manually if they care, or wait for a future skill rename to demonstrate the sweep working.

After this first run, the manifest exists and the sweep runs cleanly on every subsequent rename/removal.

## Test plan

- [ ] \`tl setup claude\` → status output reports installed skills + any swept; manifest file appears in \`~/.claude/skills/\`.
- [ ] Rename a skill in this branch's \`skills/\` dir locally, re-run \`tl setup claude\` → the old name is removed, new name installed.
- [ ] Drop a hand-written skill into \`~/.claude/skills/\` (e.g. \`my-thing/SKILL.md\`) and re-run \`tl setup claude\` → \`my-thing\` survives.
- [ ] \`tl setup opencode\` → same behaviour against \`~/.config/opencode/skills/\`.
- [ ] \`tl setup claude --json\` → JSON output includes \`orphaned_skills_swept\` field.

## Resolves the open follow-up from

[tl-cli#42](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/42) (skill rename → \`tl-import\`) — the migration concern flagged by the reviewer and acknowledged in that PR's body.