### PR TITLE
Pipeline tl-report-builder → tl-import for paste-into-new-report flow

### DIFF
--- a/skills/tl-import/SKILL.md
+++ b/skills/tl-import/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: tl-import
-description: Bulk-add or exclude a list of channels, brands, uploads (videos), or sponsorships against a ThoughtLeaders report (campaign). Superuser-only. Use when a request asks to import / add / exclude a batch of identifiers against a specific report ID — phrasings like "import these channels into report 1234", "add brands to campaign 5678", "exclude these channels from report Z", "bulk-add these videos to report X".
+description: |
+  Bulk-add or exclude a list of channels, brands, uploads (videos), or sponsorships against a ThoughtLeaders report (campaign). Superuser-only.
+
+  Triggers on **two shapes** of request — both go through this skill, NOT through `tl-cli:tl-report-builder`:
+
+  1. **Existing report** — the user names a target report ID or pastes a TL report URL. Examples: "import these channels into report 1234", "add brands to campaign 5678", "exclude these channels from report Z", "bulk-add these videos to report X".
+  2. **New report from a hand-picked list** — the user pastes a list of identifiers (YouTube URLs, `@handles`, `UC…` IDs, brand domains, video URLs, AdLink IDs) and asks to import them into a NEW report, with no filters / keywords / topic criteria. Examples: "import these links into a new report: <URLs>", "build a report from these channels: <list>", "create a campaign with these brands: <domains>", "make a new report containing these videos", "save these channels to a new report".
+
+  Both paths are this skill's job because `tl bulk-import` already auto-creates channels from YouTube URLs/handles and brands from website domains — no SQL resolution needed. For path 2, this skill first creates an empty container report via `tl reports create --config-file <minimal-config> --yes`, then runs `tl bulk-import` against the new report ID.
+
+  **Skip this skill** when the user wants a filter-driven report (keywords, topics, demographic floors, exclusions, look-alikes, date scopes, MSN/TPP scoping). Those go to `tl-cli:tl-report-builder`. Rule of thumb: if the request boils down to "these specific entities and nothing else", this skill. If it boils down to "entities matching <criteria>", the report-builder skill.
 ---
 
 # tl-import
@@ -9,7 +19,11 @@ Wraps the `tl bulk-import` command — submits a list of identifiers against a r
 
 ## When to use
 
-Trigger on requests like:
+Two trigger shapes — both run through this skill.
+
+### Shape A — existing report
+
+The user names a target report ID or pastes a TL report URL (`https://app.thoughtleaders.io/#/thoughtleaders?campaign=23859&…`).
 
 - "Import @mkbhd, @veritasium into report 1234"
 - "Add these brands to campaign 5678"
@@ -17,13 +31,28 @@ Trigger on requests like:
 - "Exclude these channels from report Z"
 - "Add these videos to report X"
 
-Single-identifier requests still work (the command accepts one). The reason to keep this skill separate from other report-edit flows: it's the only path that auto-creates channels from YouTube URLs / handles, and brands from website domains.
+### Shape B — new report from a hand-picked list
+
+The user pastes a list of identifiers and asks for a NEW report with no filtering criteria. No keywords, no topics, no demographic / format / date filters — just "these specific entities".
+
+- "Import these links into a new report: <50 YouTube URLs>"
+- "Build a report from these channels: @mkbhd, @veritasium, UCXuqSBlHAE6Xw-yeJA0Tunw"
+- "Create a campaign with these brands: nike.com, adidas.com, puma.com"
+- "Make a new report containing these videos: <video URLs>"
+- "Save these channels to a new report"
+
+Shape B works because `tl bulk-import` already resolves YouTube URLs / handles / `UC…` IDs to channels (and auto-creates any that aren't in TL yet) and brand domains to brands. **Do NOT pre-resolve identifiers via raw SQL** — `tl bulk-import` does it server-side in one call.
+
+Single-identifier requests still work (the command accepts one). The reason to keep this skill separate from `tl-report-builder`: this is the only path that auto-creates channels/brands from URLs/domains, and the only path that handles hand-picked lists without trying to invent filters.
 
 ## Inputs to gather
 
 Before running, confirm:
 
-1. **Report ID** (`--campaign` / `-c`) — required. If the user pastes a TL URL (e.g. `https://app.thoughtleaders.io/#/thoughtleaders?campaign=23859&...`), the integer after `campaign=` is the ID.
+1. **Target report** — either an existing ID or new-report intent.
+   - **Existing**: a numeric ID from the prompt, or the integer after `campaign=` in a pasted TL URL.
+   - **New**: the user said "into a new report" / "build a report from these" / "create a campaign with these" / "make a report containing …" / "save these to a new report", AND no report ID is in the prompt. Go through the "Creating the container report" section below before invoking `tl bulk-import`.
+   - **Ambiguous** (list pasted, no ID, no "new" wording): ask once — *"Add these to a new report, or to an existing one (paste the report ID / URL)?"*
 2. **Entity type** — one of `channels` / `brands` / `articles` / `sponsorships`. Infer from context, but translate user-facing vocabulary:
    - YouTube URLs / handles / `UC…` IDs → `channels`
    - Domains / brand slugs → `brands`
@@ -34,7 +63,83 @@ Before running, confirm:
    - **brands**: numeric IDs, slugs, websites / domains (`example.com`)
    - **articles** (uploads): video IDs or video URLs
    - **sponsorships** (adlinks): numeric AdLink IDs only
-4. **Include vs exclude** — default is include (add to the report). Pass `--exclude` only if the user explicitly wants to remove from the report.
+
+   **Do not resolve identifiers ahead of time with `tl db pg` / raw SQL.** `tl bulk-import` handles URL → channel-ID, handle → channel-ID, and domain → brand-ID resolution server-side, and auto-creates missing entities. Pre-resolution wastes credits and time, and is the wrong tool — equality / batch resolution over the `thoughtleaders_channel` table will miss the auto-create case entirely.
+4. **Include vs exclude** — default is include (add to the report). Pass `--exclude` only if the user explicitly wants to remove from the report. `--exclude` is invalid in new-report mode (a brand-new report has nothing to exclude from); error early if the user combines them.
+
+## Creating the container report (new-report mode only)
+
+When the target is a new report, build a minimal "naked container" config and POST it via `tl reports create --config-file <path> --yes` BEFORE running `tl bulk-import`. The container holds no filters — the pasted list IS the report's content, attached via the bulk-import step.
+
+### Step 1 — Map entity → report_type
+
+| Entity | `report_type` | User-facing label |
+|---|---|---|
+| `channels` | `3` | channels report |
+| `brands` | `2` | brands report |
+| `articles` | `1` | content / videos report |
+| `sponsorships` | `8` | sponsorships / deals report |
+
+### Step 2 — Generate title + description
+
+Both fields are **mandatory** — `tl reports create` returns `Error (400): Missing required field: report_title` (or `report_description`) if either is missing or empty. Validate before saving, not at save time.
+
+- **Title** ≤ 60 chars. If the user supplied one ("call it 'Fitness Creators Q2'"), use it verbatim. Otherwise default to `"Imported <entity-label> — <N> <entity>"` (e.g. `"Imported channels — 50 channels"`). Keep it descriptive enough that the user recognises it in their saved-reports list.
+- **Description** 1–3 sentences summarising what the report contains and how it was assembled. Default template: `"Hand-picked <entity-label> imported from a user-supplied list on <YYYY-MM-DD>. <N> identifiers submitted. No filters applied — the list itself defines the report's scope."`
+
+### Step 3 — Build the minimal config
+
+```json
+{
+  "type": 2,
+  "report_type": <int from Step 1>,
+  "report_title": "<from Step 2>",
+  "report_description": "<from Step 2>",
+  "filterset": {},
+  "columns": { /* defaults — see Step 4 */ },
+  "widgets": [ /* defaults — see Step 4 */ ]
+}
+```
+
+- `type: 2` is the `DYNAMIC` Campaign-model contract — always emit this value for skill-created reports.
+- `filterset: {}` is intentional. The pasted list is attached by `tl bulk-import` in the next phase; no filter fields are needed.
+- Do NOT add `filterset.channels: [...]` / `filterset.brands: [...]` here even if you happen to have IDs. Let `tl bulk-import` own the attachment — it's the single source of truth for what's in the report, and it handles auto-create.
+
+### Step 4 — Pick default columns + widgets
+
+Source the defaults from `tl-cli:tl-report-builder`'s reference files (same plugin, sibling skill) — `references/columns_<type>.md` for the "Defaults — always include" set, plus 4–6 outreach/evaluation columns from the standard list. For widgets, use the matching schema's `_tl_default_set` for the report type.
+
+Sensible minimums (use these if `tl-report-builder` references aren't readable):
+
+- **channels (type 3)** — columns: `Channel`, `TL Channel Summary`, `Subscribers`, `Avg. Views`, `Country`, `USA Share`, `Posts Per 90 Days`, `Sponsorship Score`, `Latest AdSpot Price`. Widgets: `channel_count` metric, `views_avg_metric`, `channel_reach_at_scrape_metric`, `views_sum_histogram`, `uploads_histogram`.
+- **brands (type 2)** — columns: `Brand`, `Mentions`, `Channels Sponsored`, `Latest Sponsorship`. Widgets: brand-count metric, mentions histogram.
+- **articles (type 1)** — columns: `Title`, `Channel`, `Published`, `Views`, `Likes`. Widgets: upload-count, views-sum-histogram.
+- **sponsorships (type 8)** — columns: `Channel`, `Brand`, `Send Date`, `Status`, `Price`. Widgets: deal-count, send-date histogram.
+
+`columns` is emitted as `{"<Display Name>": {"index": <int>, "display": true}, ...}` (positional `index` matters; assign 0..N in display order). `widgets` is an array of `{type, index, width, height, aggregator}` objects per `tl-report-builder/references/intelligence_widget_schema.json` (or `sponsorship_widget_schema.json` for type 8).
+
+### Step 5 — Save the container
+
+Write the config to a portable temp path:
+
+```bash
+python -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'tl-import-container-<short-slug>.json'))"
+```
+
+Capture the printed path verbatim — on Windows it lands in `C:\Users\…\AppData\Local\Temp\`, not `/tmp/`. Write the JSON to that exact path, then:
+
+```bash
+tl reports create --config-file <that-exact-path> --yes
+```
+
+Capture the `Campaign ID` from the response — this is the `-c` value for the bulk-import step. Capture the URL too — surface it in the final user-facing message.
+
+If `tl reports create` fails:
+- **`Error (400): Missing required field: report_title`** — Step 2 didn't generate a title. Generate one, rewrite the file, retry.
+- **`Error (400): Missing required field: report_description`** — same as above for the description.
+- **Any other 400** — surface the error verbatim and stop. Don't proceed to bulk-import against a non-existent report.
+
+Now proceed to "How to invoke" below with the captured `Campaign ID` as the `-c` value.
 
 ## How to invoke
 
@@ -174,7 +279,8 @@ These are envelope-level failures, distinct from per-row `reason` values:
 
 ## What this skill does NOT do
 
-- Doesn't create reports — that's `tl-report-builder`.
-- Doesn't change report metadata (title, description, columns, filters).
-- Doesn't validate identifiers ahead of time — submit and let the per-row `reason` tell the user which ones failed. Pre-checking with `tl channels show` / etc. is wasteful (metered) and adds latency.
-- Doesn't sweep duplicates from the user's input list — submit them as-is. The response will mark the second occurrence as `Duplicate`, which is more informative than silently deduping.
+- **Doesn't build filter-driven reports** — keyword search, topic filters, demographic floors, brand exclusions, look-alikes, MSN/TPP scoping, date scopes. Those go to `tl-cli:tl-report-builder`. This skill only handles hand-picked lists (Shape B's "naked container" pattern) and existing-report bulk-attach (Shape A).
+- **Doesn't change report metadata after creation** — once the container is saved (or an existing report is targeted), this skill only adds/excludes entities. Renaming a report, changing its columns, or swapping its filters is out of scope.
+- **Doesn't resolve identifiers ahead of time** — no `tl db pg` / raw SQL to look up channel IDs from URLs / handles. `tl bulk-import` does that server-side and auto-creates anything missing. Pre-resolution wastes credits, misses the auto-create path, and is the kind of detour the skill is designed to avoid.
+- **Doesn't validate identifiers ahead of time** either — submit and let the per-row `reason` tell the user which ones failed. Pre-checking with `tl channels show` / etc. is wasteful (metered) and adds latency.
+- **Doesn't sweep duplicates** from the user's input list — submit them as-is. The response will mark the second occurrence as `Duplicate`, which is more informative than silently deduping.

--- a/skills/tl-import/SKILL.md
+++ b/skills/tl-import/SKILL.md
@@ -3,14 +3,14 @@ name: tl-import
 description: |
   Bulk-add or exclude a list of channels, brands, uploads (videos), or sponsorships against a ThoughtLeaders report (campaign). Superuser-only.
 
-  Triggers on **two shapes** of request — both go through this skill, NOT through `tl-cli:tl-report-builder`:
+  Triggers on **two shapes** of request:
 
-  1. **Existing report** — the user names a target report ID or pastes a TL report URL. Examples: "import these channels into report 1234", "add brands to campaign 5678", "exclude these channels from report Z", "bulk-add these videos to report X".
-  2. **New report from a hand-picked list** — the user pastes a list of identifiers (YouTube URLs, `@handles`, `UC…` IDs, brand domains, video URLs, AdLink IDs) and asks to import them into a NEW report, with no filters / keywords / topic criteria. Examples: "import these links into a new report: <URLs>", "build a report from these channels: <list>", "create a campaign with these brands: <domains>", "make a new report containing these videos", "save these channels to a new report".
+  1. **Existing report** — the user names a target report ID or pastes a TL report URL. Examples: "import these channels into report 1234", "add brands to campaign 5678", "exclude these channels from report Z", "bulk-add these videos to report X". This skill handles the request end-to-end.
+  2. **New report from a hand-picked list** — the user pastes a list of identifiers (YouTube URLs, `@handles`, `UC…` IDs, brand domains, video URLs, AdLink IDs) and asks to import them into a NEW report, with no filters / keywords / topic criteria. Examples: "import these links into a new report: <URLs>", "build a report from these channels: <list>", "create a campaign with these brands: <domains>", "make a new report containing these videos", "save these channels to a new report". **This is a two-skill pipeline**: `tl-import` runs FIRST to create the bare container and attach the list, then `tl-cli:tl-report-builder` runs SECOND to populate columns/widgets/title-polish/takeaways on the just-created report (via its enrich-existing mode). Identify both at planning time; run them in order; surface a single end-to-end result to the user.
 
-  Both paths are this skill's job because `tl bulk-import` already auto-creates channels from YouTube URLs/handles and brands from website domains — no SQL resolution needed. For path 2, this skill first creates an empty container report via `tl reports create --config-file <minimal-config> --yes`, then runs `tl bulk-import` against the new report ID.
+  Both paths are this skill's entry point because `tl bulk-import` already auto-creates channels from YouTube URLs/handles and brands from website domains — no SQL resolution needed.
 
-  **Skip this skill** when the user wants a filter-driven report (keywords, topics, demographic floors, exclusions, look-alikes, date scopes, MSN/TPP scoping). Those go to `tl-cli:tl-report-builder`. Rule of thumb: if the request boils down to "these specific entities and nothing else", this skill. If it boils down to "entities matching <criteria>", the report-builder skill.
+  **Skip this skill entirely** when the user wants a filter-driven report (keywords, topics, demographic floors, exclusions, look-alikes, date scopes, MSN/TPP scoping) and does NOT paste a hand-picked list. Those go straight to `tl-cli:tl-report-builder`. Rule of thumb: if the request pastes a concrete list of entities, this skill is in the pipeline. If it describes entities by criteria only, this skill is not.
 ---
 
 # tl-import
@@ -87,7 +87,7 @@ Both fields are **mandatory** — `tl reports create` returns `Error (400): Miss
 - **Title** ≤ 60 chars. If the user supplied one ("call it 'Fitness Creators Q2'"), use it verbatim. Otherwise default to `"Imported <entity-label> — <N> <entity>"` (e.g. `"Imported channels — 50 channels"`). Keep it descriptive enough that the user recognises it in their saved-reports list.
 - **Description** 1–3 sentences summarising what the report contains and how it was assembled. Default template: `"Hand-picked <entity-label> imported from a user-supplied list on <YYYY-MM-DD>. <N> identifiers submitted. No filters applied — the list itself defines the report's scope."`
 
-### Step 3 — Build the minimal config
+### Step 3 — Build the minimal container config
 
 ```json
 {
@@ -95,30 +95,16 @@ Both fields are **mandatory** — `tl reports create` returns `Error (400): Miss
   "report_type": <int from Step 1>,
   "report_title": "<from Step 2>",
   "report_description": "<from Step 2>",
-  "filterset": {},
-  "columns": { /* defaults — see Step 4 */ },
-  "widgets": [ /* defaults — see Step 4 */ ]
+  "filterset": {}
 }
 ```
 
 - `type: 2` is the `DYNAMIC` Campaign-model contract — always emit this value for skill-created reports.
 - `filterset: {}` is intentional. The pasted list is attached by `tl bulk-import` in the next phase; no filter fields are needed.
 - Do NOT add `filterset.channels: [...]` / `filterset.brands: [...]` here even if you happen to have IDs. Let `tl bulk-import` own the attachment — it's the single source of truth for what's in the report, and it handles auto-create.
+- **Don't pick columns or widgets here.** The container is intentionally bare. `tl-cli:tl-report-builder` picks columns/widgets/title-polish/takeaways in the enrichment step (Step 5 below). Picking them here would mean both skills doing the same job from different reference points.
 
-### Step 4 — Pick default columns + widgets
-
-Source the defaults from `tl-cli:tl-report-builder`'s reference files (same plugin, sibling skill) — `references/columns_<type>.md` for the "Defaults — always include" set, plus 4–6 outreach/evaluation columns from the standard list. For widgets, use the matching schema's `_tl_default_set` for the report type.
-
-Sensible minimums (use these if `tl-report-builder` references aren't readable):
-
-- **channels (type 3)** — columns: `Channel`, `TL Channel Summary`, `Subscribers`, `Avg. Views`, `Country`, `USA Share`, `Posts Per 90 Days`, `Sponsorship Score`, `Latest AdSpot Price`. Widgets: `channel_count` metric, `views_avg_metric`, `channel_reach_at_scrape_metric`, `views_sum_histogram`, `uploads_histogram`.
-- **brands (type 2)** — columns: `Brand`, `Mentions`, `Channels Sponsored`, `Latest Sponsorship`. Widgets: brand-count metric, mentions histogram.
-- **articles (type 1)** — columns: `Title`, `Channel`, `Published`, `Views`, `Likes`. Widgets: upload-count, views-sum-histogram.
-- **sponsorships (type 8)** — columns: `Channel`, `Brand`, `Send Date`, `Status`, `Price`. Widgets: deal-count, send-date histogram.
-
-`columns` is emitted as `{"<Display Name>": {"index": <int>, "display": true}, ...}` (positional `index` matters; assign 0..N in display order). `widgets` is an array of `{type, index, width, height, aggregator}` objects per `tl-report-builder/references/intelligence_widget_schema.json` (or `sponsorship_widget_schema.json` for type 8).
-
-### Step 5 — Save the container
+### Step 4 — Save the container
 
 Write the config to a portable temp path:
 
@@ -137,9 +123,21 @@ Capture the `Campaign ID` from the response — this is the `-c` value for the b
 If `tl reports create` fails:
 - **`Error (400): Missing required field: report_title`** — Step 2 didn't generate a title. Generate one, rewrite the file, retry.
 - **`Error (400): Missing required field: report_description`** — same as above for the description.
+- **`Error (400): Missing required field: columns`** (or `widgets`) — the server requires at least a baseline set. Add the always-include channels columns (`Channel`, `TL Channel Summary`, `Subscribers`) — emitted as `{"Channel": {"index": 0, "display": true}, "TL Channel Summary": {"index": 1, "display": true}, "Subscribers": {"index": 2, "display": true}}` — and retry. `tl-report-builder` will rewrite them in Step 5 anyway.
 - **Any other 400** — surface the error verbatim and stop. Don't proceed to bulk-import against a non-existent report.
 
 Now proceed to "How to invoke" below with the captured `Campaign ID` as the `-c` value.
+
+### Step 5 — After bulk-import succeeds, hand off to tl-report-builder
+
+The pipeline for new-report mode is **import + configure**, executed in order:
+
+1. **`tl-import` (this skill)** creates the bare container (Step 4) and runs `tl bulk-import` (the "How to invoke" section below) — the list is now attached to a real report.
+2. **`tl-cli:tl-report-builder`** is then invoked in **enrich-existing mode** with the captured `Campaign ID`. It picks the right columns and widgets for `report_type`, polishes the title/description, generates takeaway insights, and persists the updates via `tl reports update <id>`.
+
+After the bulk-import result table has been rendered to the user, invoke `tl-cli:tl-report-builder` with the report ID and let it own the metadata-configuration phase. The user sees: container created → list attached → report fully configured, all in one flow.
+
+Don't try to pick columns/widgets/takeaways from inside `tl-import`. That's `tl-report-builder`'s job and duplicating it here drifts the two skills apart over time.
 
 ## How to invoke
 
@@ -279,8 +277,8 @@ These are envelope-level failures, distinct from per-row `reason` values:
 
 ## What this skill does NOT do
 
-- **Doesn't build filter-driven reports** — keyword search, topic filters, demographic floors, brand exclusions, look-alikes, MSN/TPP scoping, date scopes. Those go to `tl-cli:tl-report-builder`. This skill only handles hand-picked lists (Shape B's "naked container" pattern) and existing-report bulk-attach (Shape A).
-- **Doesn't change report metadata after creation** — once the container is saved (or an existing report is targeted), this skill only adds/excludes entities. Renaming a report, changing its columns, or swapping its filters is out of scope.
+- **Doesn't pick columns, widgets, or takeaways.** That's `tl-cli:tl-report-builder`'s job — both for new-report-mode (where this skill hands off after bulk-import) and for filter-driven reports (where this skill isn't involved at all). The container this skill creates is intentionally bare.
+- **Doesn't build filter-driven reports** — keyword search, topic filters, demographic floors, brand exclusions, look-alikes, MSN/TPP scoping, date scopes. Those go to `tl-cli:tl-report-builder` directly. This skill only handles hand-picked lists.
 - **Doesn't resolve identifiers ahead of time** — no `tl db pg` / raw SQL to look up channel IDs from URLs / handles. `tl bulk-import` does that server-side and auto-creates anything missing. Pre-resolution wastes credits, misses the auto-create path, and is the kind of detour the skill is designed to avoid.
 - **Doesn't validate identifiers ahead of time** either — submit and let the per-row `reason` tell the user which ones failed. Pre-checking with `tl channels show` / etc. is wasteful (metered) and adds latency.
 - **Doesn't sweep duplicates** from the user's input list — submit them as-is. The response will mark the second occurrence as `Duplicate`, which is more informative than silently deduping.

--- a/skills/tl-import/SKILL.md
+++ b/skills/tl-import/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: tl-import
 description: |
-  Bulk-add or exclude a list of channels, brands, uploads (videos), or sponsorships against a ThoughtLeaders report (campaign). Superuser-only.
+  Include or exclude a list of channels, brands, uploads (videos), or sponsorships against an **existing** ThoughtLeaders report. Wraps `tl bulk-import`. Superuser-only.
+
+  **This skill does ONE thing**: take a target `report_id` plus a list of identifiers, and attach (or exclude) them via `tl bulk-import`. It does NOT create reports, design filters, pick columns/widgets, or generate report metadata — those are `tl-cli:tl-report-builder`'s responsibilities.
 
   Triggers on **two shapes** of request:
 
-  1. **Existing report** — the user names a target report ID or pastes a TL report URL. Examples: "import these channels into report 1234", "add brands to campaign 5678", "exclude these channels from report Z", "bulk-add these videos to report X". This skill handles the request end-to-end.
-  2. **New report from a hand-picked list** — the user pastes a list of identifiers (YouTube URLs, `@handles`, `UC…` IDs, brand domains, video URLs, AdLink IDs) and asks to import them into a NEW report, with no filters / keywords / topic criteria. Examples: "import these links into a new report: <URLs>", "build a report from these channels: <list>", "create a campaign with these brands: <domains>", "make a new report containing these videos", "save these channels to a new report". **This is a two-skill pipeline**: `tl-import` runs FIRST to create the bare container and attach the list, then `tl-cli:tl-report-builder` runs SECOND to populate columns/widgets/title-polish/takeaways on the just-created report (via its enrich-existing mode). Identify both at planning time; run them in order; surface a single end-to-end result to the user.
+  1. **Existing report** (this skill alone) — the user names a target report ID or pastes a TL report URL. Examples: "import these channels into report 1234", "add brands to campaign 5678", "exclude these channels from report Z", "bulk-add these videos to report X".
+  2. **New report from a hand-picked list** (pipeline with `tl-report-builder`) — the user pastes a list of identifiers (YouTube URLs, `@handles`, `UC…` IDs, brand domains, video URLs, AdLink IDs) and asks to import them into a NEW report, with no filters / keywords / topic criteria. Examples: "import these links into a new report: <URLs>", "build a report from these channels: <list>", "create a campaign with these brands: <domains>", "make a new report containing these videos", "save these channels to a new report". **Execution order**: `tl-cli:tl-report-builder` runs FIRST in its bare-container mode to create the empty report (correct `report_type`, columns, widgets, title, description — empty `filterset`), then `tl-import` runs SECOND against the captured `report_id` to attach the list via `tl bulk-import`. Identify both skills at planning time; chain them in that order.
 
-  Both paths are this skill's entry point because `tl bulk-import` already auto-creates channels from YouTube URLs/handles and brands from website domains — no SQL resolution needed.
+  Identification cue for shape 2: the user pasted concrete identifiers AND said something like "new report" / "build a report from these" / "create a campaign with these". The presence of identifiers is the strong signal — that's what triggers identifying `tl-import`'s involvement; the "new report" wording is what adds `tl-report-builder` to the chain.
 
-  **Skip this skill entirely** when the user wants a filter-driven report (keywords, topics, demographic floors, exclusions, look-alikes, date scopes, MSN/TPP scoping) and does NOT paste a hand-picked list. Those go straight to `tl-cli:tl-report-builder`. Rule of thumb: if the request pastes a concrete list of entities, this skill is in the pipeline. If it describes entities by criteria only, this skill is not.
+  `tl bulk-import` already auto-creates channels from YouTube URLs/handles and brands from website domains — no SQL resolution needed. The list-paste case never requires a pre-resolution step.
+
+  **Skip this skill entirely** for filter-driven reports with no hand-picked list (keywords, topics, demographic floors, exclusions, look-alikes, date scopes, MSN/TPP scoping). Those are `tl-cli:tl-report-builder` alone.
 ---
 
 # tl-import
@@ -31,7 +35,7 @@ The user names a target report ID or pastes a TL report URL (`https://app.though
 - "Exclude these channels from report Z"
 - "Add these videos to report X"
 
-### Shape B — new report from a hand-picked list
+### Shape B — new report from a hand-picked list (chained with tl-report-builder)
 
 The user pastes a list of identifiers and asks for a NEW report with no filtering criteria. No keywords, no topics, no demographic / format / date filters — just "these specific entities".
 
@@ -41,17 +45,21 @@ The user pastes a list of identifiers and asks for a NEW report with no filterin
 - "Make a new report containing these videos: <video URLs>"
 - "Save these channels to a new report"
 
-Shape B works because `tl bulk-import` already resolves YouTube URLs / handles / `UC…` IDs to channels (and auto-creates any that aren't in TL yet) and brand domains to brands. **Do NOT pre-resolve identifiers via raw SQL** — `tl bulk-import` does it server-side in one call.
+**This skill does NOT create the report.** For Shape B, the agent invokes `tl-cli:tl-report-builder` first (in its bare-container mode — see that skill's frontmatter) to create an empty report container with the correct `report_type` (3 for channels, 2 for brands, 1 for content/videos, 8 for sponsorships), default columns/widgets, polished title, and description. The report is created with an empty `filterset`. `tl-report-builder` returns the new `report_id`.
 
-Single-identifier requests still work (the command accepts one). The reason to keep this skill separate from `tl-report-builder`: this is the only path that auto-creates channels/brands from URLs/domains, and the only path that handles hand-picked lists without trying to invent filters.
+Then `tl-import` (this skill) runs against that `report_id` and attaches the pasted list via `tl bulk-import`. The single user-facing message after the chain should weave both outputs — "report created (link), 50 channels attached, 47 already in TL, 3 newly created".
+
+`tl bulk-import` resolves YouTube URLs / handles / `UC…` IDs to channels (and auto-creates any that aren't in TL yet) and brand domains to brands. **Do NOT pre-resolve identifiers via raw SQL** — `tl bulk-import` does it server-side in one call.
+
+Single-identifier requests still work (the command accepts one).
 
 ## Inputs to gather
 
 Before running, confirm:
 
-1. **Target report** — either an existing ID or new-report intent.
-   - **Existing**: a numeric ID from the prompt, or the integer after `campaign=` in a pasted TL URL.
-   - **New**: the user said "into a new report" / "build a report from these" / "create a campaign with these" / "make a report containing …" / "save these to a new report", AND no report ID is in the prompt. Go through the "Creating the container report" section below before invoking `tl bulk-import`.
+1. **Target report ID** — a numeric ID (`--campaign` / `-c`), always required by `tl bulk-import`.
+   - **Existing report** (Shape A): pull the ID from the user's prompt — a number, or the integer after `campaign=` in a pasted TL URL.
+   - **New report** (Shape B): the ID does NOT exist yet at the start of the turn. Invoke `tl-cli:tl-report-builder` first in its bare-container mode; capture the `report_id` from its response; then continue this skill against that ID.
    - **Ambiguous** (list pasted, no ID, no "new" wording): ask once — *"Add these to a new report, or to an existing one (paste the report ID / URL)?"*
 2. **Entity type** — one of `channels` / `brands` / `articles` / `sponsorships`. Infer from context, but translate user-facing vocabulary:
    - YouTube URLs / handles / `UC…` IDs → `channels`
@@ -67,77 +75,18 @@ Before running, confirm:
    **Do not resolve identifiers ahead of time with `tl db pg` / raw SQL.** `tl bulk-import` handles URL → channel-ID, handle → channel-ID, and domain → brand-ID resolution server-side, and auto-creates missing entities. Pre-resolution wastes credits and time, and is the wrong tool — equality / batch resolution over the `thoughtleaders_channel` table will miss the auto-create case entirely.
 4. **Include vs exclude** — default is include (add to the report). Pass `--exclude` only if the user explicitly wants to remove from the report. `--exclude` is invalid in new-report mode (a brand-new report has nothing to exclude from); error early if the user combines them.
 
-## Creating the container report (new-report mode only)
+## Shape B — handoff from tl-report-builder (don't create reports here)
 
-When the target is a new report, build a minimal "naked container" config and POST it via `tl reports create --config-file <path> --yes` BEFORE running `tl bulk-import`. The container holds no filters — the pasted list IS the report's content, attached via the bulk-import step.
+For Shape B (new-report-from-list), `tl-import` is the **second** step of the pipeline. The first step — creating the empty report container — is `tl-cli:tl-report-builder`'s job, NOT this skill's.
 
-### Step 1 — Map entity → report_type
+Before invoking `tl bulk-import` for a Shape B request, confirm:
 
-| Entity | `report_type` | User-facing label |
-|---|---|---|
-| `channels` | `3` | channels report |
-| `brands` | `2` | brands report |
-| `articles` | `1` | content / videos report |
-| `sponsorships` | `8` | sponsorships / deals report |
+1. `tl-cli:tl-report-builder` has already run in its bare-container mode for this turn.
+2. A new `report_id` has come back from that skill's `tl reports create --config-file ... --yes` call.
 
-### Step 2 — Generate title + description
+Then proceed to "How to invoke" below with that `report_id` as the `-c` value.
 
-Both fields are **mandatory** — `tl reports create` returns `Error (400): Missing required field: report_title` (or `report_description`) if either is missing or empty. Validate before saving, not at save time.
-
-- **Title** ≤ 60 chars. If the user supplied one ("call it 'Fitness Creators Q2'"), use it verbatim. Otherwise default to `"Imported <entity-label> — <N> <entity>"` (e.g. `"Imported channels — 50 channels"`). Keep it descriptive enough that the user recognises it in their saved-reports list.
-- **Description** 1–3 sentences summarising what the report contains and how it was assembled. Default template: `"Hand-picked <entity-label> imported from a user-supplied list on <YYYY-MM-DD>. <N> identifiers submitted. No filters applied — the list itself defines the report's scope."`
-
-### Step 3 — Build the minimal container config
-
-```json
-{
-  "type": 2,
-  "report_type": <int from Step 1>,
-  "report_title": "<from Step 2>",
-  "report_description": "<from Step 2>",
-  "filterset": {}
-}
-```
-
-- `type: 2` is the `DYNAMIC` Campaign-model contract — always emit this value for skill-created reports.
-- `filterset: {}` is intentional. The pasted list is attached by `tl bulk-import` in the next phase; no filter fields are needed.
-- Do NOT add `filterset.channels: [...]` / `filterset.brands: [...]` here even if you happen to have IDs. Let `tl bulk-import` own the attachment — it's the single source of truth for what's in the report, and it handles auto-create.
-- **Don't pick columns or widgets here.** The container is intentionally bare. `tl-cli:tl-report-builder` picks columns/widgets/title-polish/takeaways in the enrichment step (Step 5 below). Picking them here would mean both skills doing the same job from different reference points.
-
-### Step 4 — Save the container
-
-Write the config to a portable temp path:
-
-```bash
-python -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'tl-import-container-<short-slug>.json'))"
-```
-
-Capture the printed path verbatim — on Windows it lands in `C:\Users\…\AppData\Local\Temp\`, not `/tmp/`. Write the JSON to that exact path, then:
-
-```bash
-tl reports create --config-file <that-exact-path> --yes
-```
-
-Capture the `Campaign ID` from the response — this is the `-c` value for the bulk-import step. Capture the URL too — surface it in the final user-facing message.
-
-If `tl reports create` fails:
-- **`Error (400): Missing required field: report_title`** — Step 2 didn't generate a title. Generate one, rewrite the file, retry.
-- **`Error (400): Missing required field: report_description`** — same as above for the description.
-- **`Error (400): Missing required field: columns`** (or `widgets`) — the server requires at least a baseline set. Add the always-include channels columns (`Channel`, `TL Channel Summary`, `Subscribers`) — emitted as `{"Channel": {"index": 0, "display": true}, "TL Channel Summary": {"index": 1, "display": true}, "Subscribers": {"index": 2, "display": true}}` — and retry. `tl-report-builder` will rewrite them in Step 5 anyway.
-- **Any other 400** — surface the error verbatim and stop. Don't proceed to bulk-import against a non-existent report.
-
-Now proceed to "How to invoke" below with the captured `Campaign ID` as the `-c` value.
-
-### Step 5 — After bulk-import succeeds, hand off to tl-report-builder
-
-The pipeline for new-report mode is **import + configure**, executed in order:
-
-1. **`tl-import` (this skill)** creates the bare container (Step 4) and runs `tl bulk-import` (the "How to invoke" section below) — the list is now attached to a real report.
-2. **`tl-cli:tl-report-builder`** is then invoked in **enrich-existing mode** with the captured `Campaign ID`. It picks the right columns and widgets for `report_type`, polishes the title/description, generates takeaway insights, and persists the updates via `tl reports update <id>`.
-
-After the bulk-import result table has been rendered to the user, invoke `tl-cli:tl-report-builder` with the report ID and let it own the metadata-configuration phase. The user sees: container created → list attached → report fully configured, all in one flow.
-
-Don't try to pick columns/widgets/takeaways from inside `tl-import`. That's `tl-report-builder`'s job and duplicating it here drifts the two skills apart over time.
+If the user pastes a Shape B prompt and `tl-report-builder` hasn't run yet in this turn, **invoke it first**. Do NOT call `tl reports create` from inside this skill — that would duplicate `tl-report-builder`'s scope (column/widget/title/description selection) and the two skills would drift apart over time. The only CLI command this skill owns is `tl bulk-import`.
 
 ## How to invoke
 
@@ -277,8 +226,9 @@ These are envelope-level failures, distinct from per-row `reason` values:
 
 ## What this skill does NOT do
 
-- **Doesn't pick columns, widgets, or takeaways.** That's `tl-cli:tl-report-builder`'s job — both for new-report-mode (where this skill hands off after bulk-import) and for filter-driven reports (where this skill isn't involved at all). The container this skill creates is intentionally bare.
-- **Doesn't build filter-driven reports** — keyword search, topic filters, demographic floors, brand exclusions, look-alikes, MSN/TPP scoping, date scopes. Those go to `tl-cli:tl-report-builder` directly. This skill only handles hand-picked lists.
-- **Doesn't resolve identifiers ahead of time** — no `tl db pg` / raw SQL to look up channel IDs from URLs / handles. `tl bulk-import` does that server-side and auto-creates anything missing. Pre-resolution wastes credits, misses the auto-create path, and is the kind of detour the skill is designed to avoid.
+- **Doesn't create reports. Ever.** Including bare-container reports for Shape B. The CLI command `tl reports create` is not invoked from this skill. Report creation — full or bare — is `tl-cli:tl-report-builder`'s scope. If a Shape B request arrives and no report exists, hand off to `tl-report-builder` first; come back to this skill once it returns a `report_id`.
+- **Doesn't pick columns, widgets, titles, descriptions, or takeaways.** Same reason — those are `tl-report-builder`'s responsibility.
+- **Doesn't design filters.** No keyword research, topic matching, demographic floors, brand exclusions, look-alikes, MSN/TPP scoping, date scopes. Filter-driven reports go straight to `tl-report-builder` (no `tl-import` involvement at all).
+- **Doesn't resolve identifiers ahead of time.** No `tl db pg` / raw SQL to look up channel IDs from URLs / handles. `tl bulk-import` does that server-side and auto-creates anything missing. Pre-resolution wastes credits, misses the auto-create path, and is the kind of detour the skill is designed to avoid.
 - **Doesn't validate identifiers ahead of time** either — submit and let the per-row `reason` tell the user which ones failed. Pre-checking with `tl channels show` / etc. is wasteful (metered) and adds latency.
 - **Doesn't sweep duplicates** from the user's input list — submit them as-is. The response will mark the second occurrence as `Duplicate`, which is more informative than silently deduping.

--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -13,9 +13,9 @@ description: |
 
   Save-intent variants ("save a campaign of …", "create the report …", "make a TL report for …") trigger auto-save; everything else previews. Off-taxonomy keywords ("crypto / Web3"), brand-exclusion logic ("not pitched to X"), demographic floors ("US audience ≥30%"), TPP/MSN scoping, and competitive-pitch shapes are all this skill's job — not the general `tl-cli:tl` data-analyst skill.
 
-  **Enrich-existing mode** — when invoked with an existing `report_id` (typically as the second half of a `tl-cli:tl-import` pipeline, or directly by the user via phrasings like "configure report 1234", "set up columns and widgets for report 5678", "upgrade this bare report", "add proper columns/widgets/takeaways to <report URL>"), skip Phase 1 (report type is already set on the existing report) and Phase 2 (filters/keyword/sample work is already done — the M2M-attached entities define the report's scope). Run Phase 3 (columns) and Phase 4 (widgets, title-polish, description, takeaways) only, and persist via `tl reports update <id> '<json-fields>'` instead of `tl reports create`. Hand-picked-list paste requests come in through `tl-cli:tl-import` first (which creates a bare container + runs `tl bulk-import`); this skill then takes the captured report ID and finishes the configuration. Identify both skills at planning time when a paste-and-create-new-report prompt arrives — they run in order.
+  **Bare-container mode** — when the user pastes a list of hand-picked identifiers (YouTube URLs / `@handles` / `UC…` IDs / brand domains / video URLs / AdLink IDs) and asks for a NEW report (phrasings: "import these links into a new report", "build a report from these channels", "create a campaign with these brands", "make a new report containing these videos", "save these channels to a new report"). The list will be attached by `tl-cli:tl-import` in the **next** step of the chain — but this skill runs FIRST to create the empty container. Skip Phase 2 (no filters to design — `filterset` is intentionally empty; the list, not a filter, defines the report's scope). Run Phase 1 (report type — derive from the entity shape of the pasted identifiers: YouTube → channels = 3, domains → brands = 2, video URLs → content = 1, AdLink IDs → sponsorships = 8), Phase 3 (columns appropriate for the report type), and Phase 4 (widgets, polished title using any niche hint from the prompt, description, takeaways framed around "this is a hand-picked report — N entities will be attached next"). Save via `tl reports create --config-file <path> --yes` with the full bare-container config and return the new `report_id` so `tl-import` can proceed. Identify both skills at planning time when a list-paste-into-new-report prompt arrives; **this skill runs first**, then `tl-cli:tl-import`.
 
-  **Skip this skill entirely** for: counts, metrics, trends, single-record show-by-ID lookups, raw exploratory queries, or analytical questions that aren't shaped as "give me a list". Those go to `tl-cli:tl`. Hand-picked-list paste with no filtering criteria → `tl-cli:tl-import` first; this skill runs as the second half of that pipeline.
+  **Skip this skill entirely** for: counts, metrics, trends, single-record show-by-ID lookups, raw exploratory queries, or analytical questions that aren't shaped as "give me a list". Those go to `tl-cli:tl`.
 ---
 
 # TL Report Builder Skill
@@ -1616,63 +1616,54 @@ If the slug is missing or empty for a row, fall back to the ID-based path the pl
 22. **Phases 1–4 always run; the skill never short-circuits to a chat-only data answer.** When the skill is invoked, the output is **always** a Campaign (save mode) or a Phase-4 preview (preview mode). Bypassing Phase 1–4 to produce a verification table, an analyst summary, a list cross-check, or any other "I'll just answer this directly in chat" deliverable is a regression bug. Real example to internalise: a prompt of *"Brands sponsoring Linus Tech Tips in the past 6 months: dbrand, Private Internet Access, Squarespace, Vessi, Secretlab, UGREEN, Odoo, Dell, Razer, Saily"* should route through Phase 1 → Type 2 brands report scoped to channel 1788 + last 180 days → Phases 2/3/4 → preview with the user's seed brands as a starting filter and the takeaways calling out *"your seed list is accurate but incomplete — TL data shows 60 distinct sponsors over 131 videos; top missing are War Thunder (7), Boot.dev (6), DeleteMe (6)…"*. Instead, a recent run produced exactly that analytical content **as a free-floating markdown table in chat** — no FilterSet emitted, no columns picked, no widgets, no save option. The analytical insight is welcome as a takeaway; it is **not** a substitute for the report. If you find yourself replying with a markdown table directly, ask: am I about to ship a Phase-4 preview, or am I bypassing the phases? The answer must always be the former.
 23. **No ad-hoc data-engineering pipelines.** The skill does NOT write Python consolidation scripts, multi-stage CSV merge tools, dedupe scripts, false-positive filters as standalone files, or any other custom data pipeline as part of producing the deliverable. The data plane is fixed: `tl db pg` (PG), `tl db es` (ES), `tl db fb` (Firebolt). Phase 2 issues queries against these directly to compose a FilterSet and validate it; that's the entire data-side surface. A real aviation/non-MSN run produced this anti-pattern: the agent issued five separate PG queries each writing a CSV (`/tmp/aviation_by_name.csv`, `/tmp/aviation_desc.csv`, `/tmp/aviation_desc2.csv`, `/tmp/aviation_desc3.csv`, `/tmp/aviation_pilot_desc.csv`), wrote a `consolidate_aviation.py` script to merge + dedupe + filter false positives, hit a Windows-vs-Linux `/tmp/` path mismatch, debugged it with `cygpath`, eventually rewrote the script to use `%LOCALAPPDATA%\Temp`, then produced `aviation_consolidated.csv` as the "full list". **None of this is the skill's job.** The right shape: one ES query with `terms` / `bool.should` filters covering the niche keywords + the `creator_countries` filter + `msn_channels_only: false` + `is_active: true` → get count + sample → emit the FilterSet → preview. If the skill's narration is starting to read like a data engineer's bash session ("Run consolidation script", "Try /tmp path resolution", "Resolve /tmp via cygpath", "Find where /tmp files actually are"), stop — the skill has gone off the rails. Restart from Phase 1 with a single composed query.
 
-## Enrich-existing mode (post-import handoff)
+## Bare-container mode (first half of the tl-import pipeline)
 
-A second entry point alongside the standard "build from natural language" path. Triggered when this skill is invoked with an **existing `report_id`** — either programmatically as the second half of a `tl-cli:tl-import` pipeline (after `tl bulk-import` finishes attaching a hand-picked list), or directly by the user with phrasings like *"configure report 1234"*, *"set up columns and widgets for report 5678"*, *"upgrade this bare report at <TL URL>"*, *"add proper takeaways to report 9999"*.
+A second entry point alongside the standard "build from natural language" path. Triggered when the user pastes a list of hand-picked identifiers (YouTube URLs / `@handles` / `UC…` IDs / brand domains / video URLs / AdLink IDs) and asks for a NEW report — phrasings like *"import these links into a new report"*, *"build a report from these channels"*, *"create a campaign with these brands"*, *"make a new report containing these videos"*, *"save these channels to a new report"*.
 
-The goal is the same as standard mode — a fully-configured TL report — but the inputs are different: the report exists, its `report_type` and `filterset` (or M2M attachments) are already set, and only the **metadata layer** (columns, widgets, title-polish, description, takeaways) needs to be filled in.
+In this mode, the report's content is defined by the pasted list — NOT by filters. The list itself will be attached to the report by `tl-cli:tl-import` in the **next** step of the chain. This skill's job is to create the empty container that `tl-import` can then bulk-import into: correct `report_type`, a sensible default column set, default widgets, polished title, description, and a takeaway that frames the report as ready for list attachment.
+
+Identification cue: the prompt contains concrete identifiers AND new-report intent. The agent identifies both `tl-cli:tl-import` (because of the list) and this skill (because of "new report") at planning time. Execution order: **this skill runs first**, then `tl-cli:tl-import` attaches the list against the returned `report_id`.
 
 ### Inputs
-- `report_id` — required.
-- `entity_context` — the entity type the import attached (`channels` / `brands` / `articles` / `sponsorships`). Passed by `tl-import` in the handoff; derivable from the user's prompt context otherwise.
-- `niche_hint` (optional) — any topical hint from the original user prompt ("import these fitness creators…", "these crypto channels…") that should colour the title/description/takeaways. The skill does NOT add filters from this hint — the M2M list defines the report's scope, not the niche label.
+- `entity_context` — the entity type derived from the pasted identifiers' shape:
+  - YouTube URLs / `@handles` / `UC…` IDs → `channels` → `report_type` 3
+  - Brand domains / brand slugs → `brands` → `report_type` 2
+  - Video URLs / video IDs → `articles` (content) → `report_type` 1
+  - AdLink IDs (numeric) → `sponsorships` → `report_type` 8
+- `niche_hint` (optional) — any topical hint from the user's wording (*"these fitness creators"*, *"crypto channels"*, *"my Q2 prospects"*) that should colour the title/description. Do NOT translate this into filter fields — the hint is a label for human discoverability, not a query.
+- `identifier_count` — how many entities the user pasted. Used in the title/description so the report is recognisable in the saved-reports list.
 
 ### Process
-1. **Skip Phase 1.** Report type is already set on the existing report. Don't ask, don't re-derive — `report_type` is in the handoff or pulled from the saved report via `tl reports run <id> --json` (the response envelope echoes the report_type; one cheap call is acceptable here, but only if the handoff didn't already include it).
-2. **Skip Phase 2.** Filters and the entity list are already on the report. The M2M-attached entities ARE the data — don't re-validate them via db_count/db_sample, don't run topic_matcher/keyword_research/cross_reference logic. Those phases exist to design a FilterSet from natural language; here the FilterSet is fixed.
-3. **Run Phase 3 (Columns).** Pick columns per `references/columns_<type>.md`'s "Defaults — always include" plus 4–7 outreach/evaluation columns appropriate for the report type. Use `niche_hint` only to nudge between outreach-flavored vs discovery-flavored column sets — never to add filtering columns or content-keyword logic.
-4. **Run Phase 4 (Widgets + composition).** Pick widgets per the matching widget schema's default set for the report type. Compose `report_title` (≤60 chars, polished from `niche_hint` + entity_context — e.g. *"Fitness Creators — 50 hand-picked channels"* beats `tl-import`'s default *"Imported channels — 50 channels"*) and `report_description` (1–3 sentences referencing the import context: where the list came from, how many entities, no filters applied beyond the pinned list). Compose 2–4 takeaways (entity count by `inputs_envelope` if available — how many were newly created vs already in TL, US-share distribution of the attached channels, top-3-by-reach sample, any unresolved-input warnings worth surfacing from the import phase).
-5. **Run the FINAL JSON-shape validation pass** from Phase 4 against the composed update payload — `report_title` non-empty ≤60, `report_description` non-empty, every column in the type's column file, every widget aggregator in the matching catalog, sort references an emitted column.
-6. **Persist via `tl reports update`, NOT `tl reports create`.** The container already exists; this is an in-place update.
-
-### Save mechanics (enrich-existing)
-
-```bash
-# fields-json is just the metadata diff: columns, widgets, report_title, report_description
-python -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'tl-report-builder-enrich-<short-slug>.json'))"
-# → write the fields JSON to that path, then:
-tl reports update <report_id> "$(cat <that-path>)"
-```
-
-`tl reports update` accepts a JSON object of fields to update; unknown keys come back as `400`. **Only emit the keys you're actually changing** (`columns`, `widgets`, `report_title`, `report_description`, optionally `histogram_bucket_size`). Do NOT re-emit `filterset` / `filters_json` / `type` / `report_type` — those are already correct on the existing report, and round-tripping them risks accidentally clobbering the M2M attachments from `tl bulk-import`.
-
-If the update fails:
-- **`Error (400): Unknown field …`** — drop the offending key from the fields JSON and retry. The skill should only be emitting `columns` / `widgets` / `report_title` / `report_description` / `histogram_bucket_size` in this mode; anything else is an invalid emission.
-- **Any other 400** — surface verbatim and stop.
+1. **Phase 1 (Report type)** — derive from `entity_context` per the table above. No follow-up needed; the entity shape is unambiguous from the pasted identifiers.
+2. **Skip Phase 2 entirely.** No filters to design — `filterset` is intentionally empty. The pasted list, not a filter, defines the report's scope. Don't run `topic_matcher`, `keyword_research`, `cross_references`, `db_count`, `db_sample`, or `sample_judge`. Don't add `keywords` / `topics` / `creator_countries` / `reach_from` / any other filter field — even if `niche_hint` would tempt one. The downstream `tl bulk-import` defines the report's content.
+3. **Run Phase 3 (Columns).** Pick per `references/columns_<type>.md`'s "Defaults — always include" plus 4–7 outreach/evaluation columns appropriate for the report type. Use `niche_hint` only to nudge between outreach-flavored vs discovery-flavored column sets — never to add filtering columns.
+4. **Run Phase 4 (Widgets + composition).** Pick widgets per the matching widget schema's default set for the report type.
+   - **Title** ≤ 60 chars. If `niche_hint` is present, use it: *"Fitness Creators — 50 hand-picked channels"*. Otherwise: *"Imported <entity-label> — <N> <entity>"* (e.g. *"Imported channels — 50 channels"*).
+   - **Description** 1–3 sentences. Default template: *"Hand-picked <entity-label> imported from a user-supplied list on <YYYY-MM-DD>. <N> identifiers to be attached. No filters applied — the list itself defines the report's scope."*
+   - **Takeaways** 1–2 short lines framed around the import-prep outcome: *"Container ready — <N> <entity> will be attached next via bulk-import."* The full takeaway story (newly-created, top-by-reach, US-share distribution) belongs after `tl-import` runs, narrated by the agent in the consolidated user-facing message.
+5. **Run the FINAL JSON-shape validation pass** as in standard mode. Required fields: `report_title` non-empty ≤60, `report_description` non-empty 1–3 sentences, `type: 2`, `report_type` ∈ {1, 2, 3, 8}, every column in the type's column file, every widget aggregator in the matching catalog, `filterset: {}`.
+6. **Save via `tl reports create --config-file <path> --yes`** as in standard mode. Capture the `Campaign ID` from the response — this is the `-c` value `tl-cli:tl-import` will use against `tl bulk-import` in the next step.
 
 ### Differences from standard mode (cheat sheet)
 
-| Aspect | Standard mode | Enrich-existing mode |
+| Aspect | Standard mode | Bare-container mode |
 |---|---|---|
-| Trigger | Natural-language report request | Existing `report_id` (handoff or user-supplied) |
-| Phase 1 | Routes report type | Skipped — report type already set |
-| Phase 2 | Designs + validates FilterSet | Skipped — filters/M2M already set |
+| Trigger | Natural-language filter-driven request | Hand-picked-list paste + new-report intent |
+| Phase 1 | Routes report type from the prompt | Derives report type from pasted-identifier shape |
+| Phase 2 | Designs + validates FilterSet | Skipped — `filterset: {}` intentionally |
 | Phase 3 | Picks columns | Picks columns (same logic) |
-| Phase 4 | Picks widgets + title/desc/takeaways | Picks widgets + title/desc/takeaways |
-| Persistence | `tl reports create --config-file <full-config> --yes` | `tl reports update <id> <fields-diff>` |
-| Emits `filterset` / `report_type` / `type`? | Yes — full config | No — only the metadata diff |
-| Takeaway content | Filter-result framing (count classification, sample_judge, narrow-result notes) | Import-result framing (entities attached, newly-created, top-by-reach from the attached set, unresolved-input warnings) |
+| Phase 4 takeaways | Filter-result framing (count, sample, narrow notes) | "Container ready — N to be attached" |
+| Persistence | `tl reports create --config-file <full-config> --yes` | Same — full config with empty `filterset` |
+| What runs next | Nothing (skill is the deliverable) | `tl-cli:tl-import` against the returned `report_id` |
 
 ### Hand-off contract with `tl-import`
 
-When `tl-import` chains into this skill at the end of its new-report-mode pipeline, it passes (or makes available in the conversation):
-- `report_id` from `tl reports create`
-- `report_type` from the container config
-- `entity_context` matching the bulk-import entity argument
-- `inputs_envelope` from the `tl bulk-import` response — useful for the takeaway about newly-created vs already-in-TL counts
-- `niche_hint` if the original user prompt named one
+After save, surface the captured `report_id` so `tl-cli:tl-import` can run against it. The conversation already has `entity_context` and the pasted identifier list; the agent threads them into the next-step invocation. The single end-to-end user-facing message at the end of the chain is composed by the agent weaving:
 
-The single user-facing message after the chain completes is composed by this skill (since it runs last), and should weave the import outcome (rows added / newly created / failed) into the takeaways so the user sees one end-to-end result, not two stitched-together skill outputs.
+- This skill's output: *"TL report created — <title> (report #N) — <link>"*
+- `tl-import`'s output: *"<N> entities attached, <K> already in TL, <M> newly created, <X> failed"*
+
+Don't duplicate `tl-import`'s rendering into this skill's output. Each skill renders its own slice; the agent stitches them for the user.
 
 ## Follow-Up Interactions
 

--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -13,7 +13,7 @@ description: |
 
   Save-intent variants ("save a campaign of …", "create the report …", "make a TL report for …") trigger auto-save; everything else previews. Off-taxonomy keywords ("crypto / Web3"), brand-exclusion logic ("not pitched to X"), demographic floors ("US audience ≥30%"), TPP/MSN scoping, and competitive-pitch shapes are all this skill's job — not the general `tl-cli:tl` data-analyst skill.
 
-  **Skip this skill** only for: counts, metrics, trends, single-record show-by-ID lookups, raw exploratory queries, or analytical questions that aren't shaped as "give me a list". Those go to `tl-cli:tl`.
+  **Skip this skill** for: counts, metrics, trends, single-record show-by-ID lookups, raw exploratory queries, or analytical questions that aren't shaped as "give me a list" (those go to `tl-cli:tl`); AND for **hand-picked-list imports** — when the user pastes a list of YouTube URLs / `@handles` / `UC…` IDs / brand domains / video URLs / AdLink IDs and asks to put them into a new or existing report with NO filtering criteria. That's `tl-cli:tl-import`'s job — it auto-creates the container report (if asked) and runs `tl bulk-import`, which resolves URLs server-side and auto-creates missing entities. Don't try to resolve the URLs yourself via `tl db pg` — it's the wrong tool and wastes credits.
 ---
 
 # TL Report Builder Skill

--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -13,7 +13,9 @@ description: |
 
   Save-intent variants ("save a campaign of …", "create the report …", "make a TL report for …") trigger auto-save; everything else previews. Off-taxonomy keywords ("crypto / Web3"), brand-exclusion logic ("not pitched to X"), demographic floors ("US audience ≥30%"), TPP/MSN scoping, and competitive-pitch shapes are all this skill's job — not the general `tl-cli:tl` data-analyst skill.
 
-  **Skip this skill** for: counts, metrics, trends, single-record show-by-ID lookups, raw exploratory queries, or analytical questions that aren't shaped as "give me a list" (those go to `tl-cli:tl`); AND for **hand-picked-list imports** — when the user pastes a list of YouTube URLs / `@handles` / `UC…` IDs / brand domains / video URLs / AdLink IDs and asks to put them into a new or existing report with NO filtering criteria. That's `tl-cli:tl-import`'s job — it auto-creates the container report (if asked) and runs `tl bulk-import`, which resolves URLs server-side and auto-creates missing entities. Don't try to resolve the URLs yourself via `tl db pg` — it's the wrong tool and wastes credits.
+  **Enrich-existing mode** — when invoked with an existing `report_id` (typically as the second half of a `tl-cli:tl-import` pipeline, or directly by the user via phrasings like "configure report 1234", "set up columns and widgets for report 5678", "upgrade this bare report", "add proper columns/widgets/takeaways to <report URL>"), skip Phase 1 (report type is already set on the existing report) and Phase 2 (filters/keyword/sample work is already done — the M2M-attached entities define the report's scope). Run Phase 3 (columns) and Phase 4 (widgets, title-polish, description, takeaways) only, and persist via `tl reports update <id> '<json-fields>'` instead of `tl reports create`. Hand-picked-list paste requests come in through `tl-cli:tl-import` first (which creates a bare container + runs `tl bulk-import`); this skill then takes the captured report ID and finishes the configuration. Identify both skills at planning time when a paste-and-create-new-report prompt arrives — they run in order.
+
+  **Skip this skill entirely** for: counts, metrics, trends, single-record show-by-ID lookups, raw exploratory queries, or analytical questions that aren't shaped as "give me a list". Those go to `tl-cli:tl`. Hand-picked-list paste with no filtering criteria → `tl-cli:tl-import` first; this skill runs as the second half of that pipeline.
 ---
 
 # TL Report Builder Skill
@@ -1613,6 +1615,64 @@ If the slug is missing or empty for a row, fall back to the ID-based path the pl
 21. **No side-channel deliverables.** The skill produces exactly two output shapes: (a) a saved TL Campaign + a campaign URL (save mode), or (b) an in-chat preview with the sample-rows table + takeaways + save tail (preview mode). It does NOT write CSVs, Markdown reports, or any other "data dump" file to disk as a deliverable. A real run for FRÉ Skincare wrote a CSV to `<temp>\fre-skincare-shortlist.csv` and pointed the user at it as the "full list" — that's a fabricated alternative deliverable that bypasses the TL report-creation flow. If the user wants more than the preview shows, the answer is "save it as a campaign and run it" — not "I'll dump CSV". The only filesystem write the skill is allowed to make is the `<system-temp>/tl-report-builder-<slug>.json` transport file used in step 1 of the save mechanics, and even that is a transport (deleted whenever) — never a deliverable.
 22. **Phases 1–4 always run; the skill never short-circuits to a chat-only data answer.** When the skill is invoked, the output is **always** a Campaign (save mode) or a Phase-4 preview (preview mode). Bypassing Phase 1–4 to produce a verification table, an analyst summary, a list cross-check, or any other "I'll just answer this directly in chat" deliverable is a regression bug. Real example to internalise: a prompt of *"Brands sponsoring Linus Tech Tips in the past 6 months: dbrand, Private Internet Access, Squarespace, Vessi, Secretlab, UGREEN, Odoo, Dell, Razer, Saily"* should route through Phase 1 → Type 2 brands report scoped to channel 1788 + last 180 days → Phases 2/3/4 → preview with the user's seed brands as a starting filter and the takeaways calling out *"your seed list is accurate but incomplete — TL data shows 60 distinct sponsors over 131 videos; top missing are War Thunder (7), Boot.dev (6), DeleteMe (6)…"*. Instead, a recent run produced exactly that analytical content **as a free-floating markdown table in chat** — no FilterSet emitted, no columns picked, no widgets, no save option. The analytical insight is welcome as a takeaway; it is **not** a substitute for the report. If you find yourself replying with a markdown table directly, ask: am I about to ship a Phase-4 preview, or am I bypassing the phases? The answer must always be the former.
 23. **No ad-hoc data-engineering pipelines.** The skill does NOT write Python consolidation scripts, multi-stage CSV merge tools, dedupe scripts, false-positive filters as standalone files, or any other custom data pipeline as part of producing the deliverable. The data plane is fixed: `tl db pg` (PG), `tl db es` (ES), `tl db fb` (Firebolt). Phase 2 issues queries against these directly to compose a FilterSet and validate it; that's the entire data-side surface. A real aviation/non-MSN run produced this anti-pattern: the agent issued five separate PG queries each writing a CSV (`/tmp/aviation_by_name.csv`, `/tmp/aviation_desc.csv`, `/tmp/aviation_desc2.csv`, `/tmp/aviation_desc3.csv`, `/tmp/aviation_pilot_desc.csv`), wrote a `consolidate_aviation.py` script to merge + dedupe + filter false positives, hit a Windows-vs-Linux `/tmp/` path mismatch, debugged it with `cygpath`, eventually rewrote the script to use `%LOCALAPPDATA%\Temp`, then produced `aviation_consolidated.csv` as the "full list". **None of this is the skill's job.** The right shape: one ES query with `terms` / `bool.should` filters covering the niche keywords + the `creator_countries` filter + `msn_channels_only: false` + `is_active: true` → get count + sample → emit the FilterSet → preview. If the skill's narration is starting to read like a data engineer's bash session ("Run consolidation script", "Try /tmp path resolution", "Resolve /tmp via cygpath", "Find where /tmp files actually are"), stop — the skill has gone off the rails. Restart from Phase 1 with a single composed query.
+
+## Enrich-existing mode (post-import handoff)
+
+A second entry point alongside the standard "build from natural language" path. Triggered when this skill is invoked with an **existing `report_id`** — either programmatically as the second half of a `tl-cli:tl-import` pipeline (after `tl bulk-import` finishes attaching a hand-picked list), or directly by the user with phrasings like *"configure report 1234"*, *"set up columns and widgets for report 5678"*, *"upgrade this bare report at <TL URL>"*, *"add proper takeaways to report 9999"*.
+
+The goal is the same as standard mode — a fully-configured TL report — but the inputs are different: the report exists, its `report_type` and `filterset` (or M2M attachments) are already set, and only the **metadata layer** (columns, widgets, title-polish, description, takeaways) needs to be filled in.
+
+### Inputs
+- `report_id` — required.
+- `entity_context` — the entity type the import attached (`channels` / `brands` / `articles` / `sponsorships`). Passed by `tl-import` in the handoff; derivable from the user's prompt context otherwise.
+- `niche_hint` (optional) — any topical hint from the original user prompt ("import these fitness creators…", "these crypto channels…") that should colour the title/description/takeaways. The skill does NOT add filters from this hint — the M2M list defines the report's scope, not the niche label.
+
+### Process
+1. **Skip Phase 1.** Report type is already set on the existing report. Don't ask, don't re-derive — `report_type` is in the handoff or pulled from the saved report via `tl reports run <id> --json` (the response envelope echoes the report_type; one cheap call is acceptable here, but only if the handoff didn't already include it).
+2. **Skip Phase 2.** Filters and the entity list are already on the report. The M2M-attached entities ARE the data — don't re-validate them via db_count/db_sample, don't run topic_matcher/keyword_research/cross_reference logic. Those phases exist to design a FilterSet from natural language; here the FilterSet is fixed.
+3. **Run Phase 3 (Columns).** Pick columns per `references/columns_<type>.md`'s "Defaults — always include" plus 4–7 outreach/evaluation columns appropriate for the report type. Use `niche_hint` only to nudge between outreach-flavored vs discovery-flavored column sets — never to add filtering columns or content-keyword logic.
+4. **Run Phase 4 (Widgets + composition).** Pick widgets per the matching widget schema's default set for the report type. Compose `report_title` (≤60 chars, polished from `niche_hint` + entity_context — e.g. *"Fitness Creators — 50 hand-picked channels"* beats `tl-import`'s default *"Imported channels — 50 channels"*) and `report_description` (1–3 sentences referencing the import context: where the list came from, how many entities, no filters applied beyond the pinned list). Compose 2–4 takeaways (entity count by `inputs_envelope` if available — how many were newly created vs already in TL, US-share distribution of the attached channels, top-3-by-reach sample, any unresolved-input warnings worth surfacing from the import phase).
+5. **Run the FINAL JSON-shape validation pass** from Phase 4 against the composed update payload — `report_title` non-empty ≤60, `report_description` non-empty, every column in the type's column file, every widget aggregator in the matching catalog, sort references an emitted column.
+6. **Persist via `tl reports update`, NOT `tl reports create`.** The container already exists; this is an in-place update.
+
+### Save mechanics (enrich-existing)
+
+```bash
+# fields-json is just the metadata diff: columns, widgets, report_title, report_description
+python -c "import tempfile, os; print(os.path.join(tempfile.gettempdir(), 'tl-report-builder-enrich-<short-slug>.json'))"
+# → write the fields JSON to that path, then:
+tl reports update <report_id> "$(cat <that-path>)"
+```
+
+`tl reports update` accepts a JSON object of fields to update; unknown keys come back as `400`. **Only emit the keys you're actually changing** (`columns`, `widgets`, `report_title`, `report_description`, optionally `histogram_bucket_size`). Do NOT re-emit `filterset` / `filters_json` / `type` / `report_type` — those are already correct on the existing report, and round-tripping them risks accidentally clobbering the M2M attachments from `tl bulk-import`.
+
+If the update fails:
+- **`Error (400): Unknown field …`** — drop the offending key from the fields JSON and retry. The skill should only be emitting `columns` / `widgets` / `report_title` / `report_description` / `histogram_bucket_size` in this mode; anything else is an invalid emission.
+- **Any other 400** — surface verbatim and stop.
+
+### Differences from standard mode (cheat sheet)
+
+| Aspect | Standard mode | Enrich-existing mode |
+|---|---|---|
+| Trigger | Natural-language report request | Existing `report_id` (handoff or user-supplied) |
+| Phase 1 | Routes report type | Skipped — report type already set |
+| Phase 2 | Designs + validates FilterSet | Skipped — filters/M2M already set |
+| Phase 3 | Picks columns | Picks columns (same logic) |
+| Phase 4 | Picks widgets + title/desc/takeaways | Picks widgets + title/desc/takeaways |
+| Persistence | `tl reports create --config-file <full-config> --yes` | `tl reports update <id> <fields-diff>` |
+| Emits `filterset` / `report_type` / `type`? | Yes — full config | No — only the metadata diff |
+| Takeaway content | Filter-result framing (count classification, sample_judge, narrow-result notes) | Import-result framing (entities attached, newly-created, top-by-reach from the attached set, unresolved-input warnings) |
+
+### Hand-off contract with `tl-import`
+
+When `tl-import` chains into this skill at the end of its new-report-mode pipeline, it passes (or makes available in the conversation):
+- `report_id` from `tl reports create`
+- `report_type` from the container config
+- `entity_context` matching the bulk-import entity argument
+- `inputs_envelope` from the `tl bulk-import` response — useful for the takeaway about newly-created vs already-in-TL counts
+- `niche_hint` if the original user prompt named one
+
+The single user-facing message after the chain completes is composed by this skill (since it runs last), and should weave the import outcome (rows added / newly created / failed) into the takeaways so the user sees one end-to-end result, not two stitched-together skill outputs.
 
 ## Follow-Up Interactions
 


### PR DESCRIPTION
## Summary

For paste-and-create-new-report prompts (e.g. *"import these 50 URLs into a new report"*), identify BOTH skills at planning time and run them in this order:

1. **`tl-report-builder`** (new **bare-container mode**) — creates the empty report container. Derives `report_type` from the entity shape of the pasted identifiers (YouTube → channels, domains → brands, video URLs → content, AdLink IDs → sponsorships). Picks default columns and widgets, generates a polished title and description. Saves via `tl reports create --config-file <full-config> --yes` with empty `filterset`. Returns the new `report_id`.
2. **`tl-import`** — bulk-imports the pasted list against that `report_id` via `tl bulk-import`.

`tl-import` does ONE thing — include/exclude entities. It never creates reports, picks columns, designs filters, or generates metadata.

## Why

A recent *"import these 50 YouTube URLs into a new report"* run routed through `tl-report-builder` (no recipe for hand-picked lists), where the agent invented a `tl db pg --sql` flag, ILIKE-timed-out resolving handles, and forgot `report_title` on first save. All avoidable because `tl bulk-import` already resolves URLs / handles / domains server-side and auto-creates missing entities.

The fix is **clean separation**:
- All report creation in `tl-report-builder` (filter-driven mode + bare-container mode for hand-picked lists).
- All entity attach/exclude in `tl-import`.
- The agent chains them in the right order for paste-into-new-report prompts.

## Changes

**`skills/tl-import/SKILL.md`** (−59 net)
- Frontmatter: skill does ONE thing — include/exclude entities against an existing report
- Shape B section: documents the prerequisite handoff from `tl-report-builder` (must run first to create the container)
- DELETED the entire "Creating the container report" section (Steps 1-5) — `tl-import` no longer creates reports
- "Does NOT do" leads with *"Doesn't create reports. Ever."*

**`skills/tl-report-builder/SKILL.md`** (+24 net)
- Frontmatter: new **bare-container mode** trigger for hand-picked-list + new-report intent
- New "Bare-container mode" section: skips Phase 2 (no filters), runs Phase 1/3/4, saves via `tl reports create` with empty `filterset`, returns `report_id` to `tl-import`
- Hand-off contract section: this skill produces `report_id`; `tl-import` consumes it

## Test plan

- [ ] Paste a list of YouTube URLs with *"import these into a new report"* → agent identifies both skills; runs `tl-report-builder` (bare-container) first to create the report, then `tl-import` to attach the list; user sees one consolidated message
- [ ] Paste a list with *"add these to report 12345"* → `tl-import` only (Shape A, end-to-end)
- [ ] Filter-driven prompt (*"gaming channels with 100K+ subs"*) → `tl-report-builder` only (standard mode)
- [ ] Verify `tl reports create` accepts the bare-container config (empty `filterset`, columns/widgets/title/description present)
- [ ] Verify `tl bulk-import` against the new report attaches entities cleanly — no metadata clobbering