### PR TITLE
step 1: define E2E success for tl-competitor-research workflow

### DIFF
--- a/skills/tl-competitor-research/SPEC.md
+++ b/skills/tl-competitor-research/SPEC.md
@@ -1,0 +1,163 @@
+# tl-competitor-research — SPEC
+
+> **Status: Step 1 of 5** — E2E success definition only. Step 2 (workflow
+> design + Report Builder composition points) is a follow-up. SKILL.md
+> doesn't exist yet; this directory holds the spec the eventual skill
+> will be measured against.
+
+## Workflow intent
+
+Translate a competitor-research goal — *"who is brand X sponsoring on
+YouTube, and where could we go next?"* — into an actionable outreach
+shortlist, by composing `tl-cli:tl-report-builder` as a component for
+the data-fetch + cross-reference steps.
+
+The workflow owns: the user-facing prompt vocabulary, brand resolution
+across competitor + user's own brand, cross-referencing the two, ranking
+adjacency, and synthesizing the answer.
+
+The workflow does NOT own: report-config validation, FilterSet shape,
+column selection, save mechanics — those stay in Report Builder.
+
+## What "success" looks like (the E2E bar)
+
+A workflow run is **successful** when the user gets, in a single reply,
+all of the following without any manual follow-up step:
+
+1. **A ranked, deduplicated list of channels** the competitor has run
+   with — top 10 by frequency, with deal count + most recent send date
+   + reach. (NOT one-row-per-deal raw data.)
+2. **An "our relationship" annotation per channel**: *"never pitched"*,
+   *"pitched but lost"*, *"active deal"*, *"do-not-contact"*.
+3. **An outreach shortlist** — the subset of the competitor's channels
+   the user has never pitched, ordered by adjacency to the user's
+   brand (audience fit, niche overlap, reach band match).
+4. **An exclusion list** — channels the user should NOT pitch (already
+   in active pipeline, on do-not-contact, prior conflict).
+5. **A saved TL report** the user can click into for full data drilling.
+
+Time-to-answer: under 3 minutes from prompt to reply.
+
+## Test prompt set (the 5 prompts this workflow must succeed on)
+
+Step 1's deliverable is the test set itself, not the workflow yet.
+These 5 prompts are what step 4 (test) will run against:
+
+### Prompt 1 — explicit competitor + user's own brand
+> *"Research Magic Spoon's YouTube footprint — where could Fusion go next?"*
+
+- **Competitor**: Magic Spoon (cereal / breakfast vertical)
+- **User's brand**: Fusion (Blackmagic Design)
+- **Resolution**: workflow must read session context to know Fusion is
+  the user's brand if not explicitly named
+- **Expected success**: ranked Magic Spoon channel list + Fusion
+  adjacency ranking + outreach shortlist excluding any Fusion has
+  already pitched
+
+### Prompt 2 — competitor only, infer user's brand from session
+> *"Who is HelloFresh sponsoring on YouTube?"*
+
+- **Competitor**: HelloFresh (meal-kit vertical)
+- **User's brand**: not stated — workflow infers from session
+- **Expected success**: same shape as prompt 1, with the workflow
+  having decided which session-context brand to anchor adjacency to
+  (or, if ambiguous, surfacing the choice as a clarifier)
+
+### Prompt 3 — workflow-shaped intent without naming "research"
+> *"What channels does Webull run with — could any of them work for us?"*
+
+- **Competitor**: Webull (fintech vertical)
+- **Intent shape**: question phrasing, not imperative
+- **Expected success**: workflow triggers on the *"work for us"*
+  framing (not on a "build me a report" framing), produces shortlist
+
+### Prompt 4 — pre-resolved brand (skip brand-lookup)
+> *"Show me [a specific brand ID]'s top YouTube spend partners"*
+
+- **Competitor**: identified by ID, not name (no name resolution)
+- **Expected success**: workflow skips the name-resolution step,
+  goes straight to the competitor's deal data. Tests that the
+  workflow doesn't blindly re-do work when the input is already
+  resolved.
+
+### Prompt 5 — niche-scoped competitor research
+> *"Who's been pitching to cooking channels lately — any patterns?"*
+
+- **Competitor**: not specified — the workflow must surface
+  competitor brands as the OUTPUT, not consume them as input
+- **Expected success**: workflow detects "find the competitors,
+  then research them" intent, surfaces top brands sponsoring the
+  niche, optionally lets the user pick one to drill into
+
+## What does NOT qualify as success
+
+The workflow run is **not successful** if the reply contains any of:
+
+- ❌ Raw report data — one-row-per-deal, no aggregation or ranking
+- ❌ A Phase 4 takeaway list that describes the report shape instead
+  of answering the user's goal (*"the report has 47 rows across
+  31 channels"* is report-shaped; *"top 10 channels with adjacency
+  ranking"* is goal-shaped)
+- ❌ A prompt back to the user that requires them to run a second
+  workflow step manually (*"now run a separate report for your own
+  brand and cross-reference"*)
+- ❌ The user has to interpret two separate reports side-by-side to
+  reach the answer
+- ❌ More than 5 minutes wall-clock from prompt to reply
+- ❌ Any of the v0.6.24 rule-compliance regressions (`Campaign #N`
+  leak, `Reach` column header, `(id N)` row suffix, etc.)
+
+## How we'll measure (step 4 ahead-of-time)
+
+When step 4 (testing) runs:
+
+| Prompt | E2E success criterion | Wall-clock budget |
+|---|---|---|
+| 1 | Outreach shortlist + adjacency + exclusions, named brands resolved | < 3 min |
+| 2 | Same as 1, but with session-context brand resolution OR clarifier | < 3 min |
+| 3 | Same as 1, triggered by goal-shaped (not report-shaped) prompt | < 3 min |
+| 4 | Same as 1, but skips name-resolution step | < 2 min |
+| 5 | Two-stage: surface competitor candidates, then drill into one | < 4 min |
+
+All 5 must pass for the workflow to be considered "nailed" per
+David's directive.
+
+## What step 2 will define (not in this spec)
+
+The next deliverable (step 2 of the template) is the **workflow
+design** — answers to:
+
+1. What's the workflow's user-facing surface (skill triggers,
+   description shape, frontmatter)?
+2. How does it invoke Report Builder?
+   - As a sub-skill via natural-language hand-off?
+   - As a sub-tool via a documented calling convention?
+   - Which Report Builder components does it need access to:
+     `name_resolver`, `similar_channels`, Type 2, Type 8, the
+     validation loop, or some subset?
+3. What's the synthesis step that turns 2-3 Report Builder outputs
+   into the workflow's single reply?
+4. What's the contract for adjacency ranking — by reach band? by
+   demographic overlap? by topic similarity? by AI-summary
+   similarity?
+5. How does the workflow handle brand-name resolution failures,
+   off-taxonomy niches, empty competitor footprints?
+6. What changes (if any) does Report Builder itself need to support
+   being invoked as a sub-tool (compose-mode? headless mode?)?
+
+Each of those is a step-2 deliverable, separate PRs as needed.
+
+## What step 3, 4, 5 will deliver (not in this spec)
+
+- **Step 3**: build the workflow's SKILL.md based on step 2's design.
+- **Step 4**: run all 5 prompts; record pass/fail per E2E criterion.
+- **Step 5**: fix issues one at a time — each fix is its own PR;
+  Report Builder gaps surface as PRs against `tl-cli:tl-report-builder`.
+
+## Definition of "nailed"
+
+All 5 prompts above pass their E2E criterion **and** the workflow has
+been in live production use (i.e. invoked by the team for real work,
+not just by the test set) for one full week without a manual fallback.
+
+Per David's directive: not "the skill exists" — actual usage proof.


### PR DESCRIPTION
**Step 1 of 5** — define E2E success for `tl-competitor-research`, the first workflow skill that composes `tl-cli:tl-report-builder` as a background tool.

## Why this PR exists

Per David Tintner's directive — Report Builder is a background tool composed by workflow skills, success measured at the workflow level, not the atomic-output level. This PR delivers ONLY the first step of the 5-step workflow-integration template:

| Step | Deliverable | Where |
|---|---|---|
| **1** | Define E2E success — what does "the user got their answer" look like? | **This PR** |
| 2 | Workflow design — invocation pattern, Report Builder composition points, synthesis step | Next PR |
| 3 | Build the workflow's SKILL.md | Follow-up |
| 4 | Test against the 5 prompts | Follow-up |
| 5 | Fix issues one at a time | Follow-up PRs |

Per the maintainer's "step 1 then step 2" sequencing — this PR is step 1 only. Step 2 starts after this lands.

## What this PR ships

Single file: `skills/tl-competitor-research/SPEC.md`. No SKILL.md (workflow isn't built yet — SKILL.md is step 3's deliverable). No code, no scripts, no version bump. Just the spec the eventual workflow will be measured against.

## What's in the SPEC

1. **Workflow intent** + scope boundaries (what the workflow owns vs. what stays in Report Builder)
2. **5-criteria E2E success bar**: ranked channel list, "our relationship" annotation, outreach shortlist, exclusion list, saved TL report. Time-to-answer < 3 min.
3. **5 test prompts** covering: explicit brand pair, session-inferred brand, goal-shaped phrasing, pre-resolved-by-ID brand, niche-scoped competitor discovery
4. **Per-prompt E2E success criterion** + wall-clock budget
5. **Failure markers** — raw report dumps, report-shaped takeaways, multi-step manual cross-referencing, v0.6.24 rule regressions
6. **Definition of "nailed"** — all 5 prompts pass AND one full week of live production use (per David's "not 'skill exists' — actual usage proof" framing)
7. **Explicit out-of-scope** for step 1 (workflow design, invocation pattern, etc.) — those are step 2's deliverables

## What step 2 will answer (preview)

Step 2 (the next PR after this one merges) will address:

- How does the workflow invoke Report Builder? (Sub-skill via narrative hand-off vs. sub-tool via documented calling convention)
- Which Report Builder components does it need access to: `name_resolver`, `similar_channels`, Type 2, Type 8, validation loop, or a subset?
- What's the synthesis step that turns 2-3 Report Builder outputs into the workflow's single reply?
- Adjacency-ranking contract (by reach band? demographic overlap? topic similarity?)
- Edge-case handling (brand-name resolution failures, off-taxonomy niches, empty competitor footprints)
- Does Report Builder itself need a "compose mode" change to support being invoked as a sub-tool?

## Why competitor-research as the first workflow

David's literal example. From the meeting transcript:

> *"the tool or its components should be integrated into a complete workflow skill, such as generating reports on a competitor's top channels"*

If we nail this one, we get the canonical pattern that subsequent workflow skills (renewal-shortlist, brand-opportunity, etc.) can follow.

## Out of scope for this PR

- Any work on the `thoughtleaders-skills` repo (scoped to `tl-cli` per the maintainer's directive)
- Integration into existing workflow skills (`pipeline-standup`, `msn-expansion`, `opportunity-hunter`) — that comes AFTER our own workflow is nailed
- SKILL.md construction — step 3
- Implementation — steps 3-5

## Next action after this PR merges

Open the step 2 PR: workflow design document covering the 6 questions listed in the "What step 2 will answer" section above.
