### PR TITLE
v0.6.28: bump version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.6.27"
+version = "0.6.28"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.6.27"
+__version__ = "0.6.28"


### PR DESCRIPTION
Ships the tl-import minimal-config fix from [#49](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/pull/49) — every new-report flow now emits a complete column-rendering shape so the dashboard shows rows with values instead of blank cells.

Routine three-file bump.