### PR TITLE
Skill: document per-table + per-column raw PG pricing

### DIFF
--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -296,6 +296,8 @@ tl db pg "SELECT b.name, COUNT(*) AS deals
 
 See [references/postgres-schema.md](references/postgres-schema.md) for the accepted-SQL rules and the table/column catalogue. `tl schema pg` prints the live table/column listing visible to the caller.
 
+**PG cost is per-query.** The credit rate for a `tl db pg` call equals a base rate plus a surcharge for every priced table referenced and every priced column referenced (additive on both sides). Most tables and columns carry no surcharge; sensitive ones (e.g. demographics, channel outreach emails) cost more. Run `tl describe show db --json` to see the live surcharge map, and check `usage.credit_rate` in the response envelope after a query to see what your query was actually charged.
+
 ### Three sources, each authoritative for different things
 
 - **Postgres** — deals, pipeline, brands, channels, users, organizations, profiles, revenue. Source of truth for deal state. Reachable via the structured `tl` commands or raw `tl db pg`.


### PR DESCRIPTION
## Summary

Server-side change in [thoughtleaders#4017](https://github.com/ThoughtLeaders-io/thoughtleaders/pull/4017) replaces the flat 1.4x multiplier for `tl db pg` with a per-query multiplier composed of a base rate plus additive surcharges for every priced table and column the query references.

Two-line addition to `skills/tl/SKILL.md` telling Claude that:

- PG cost is per-query, not flat.
- The live surcharge map is at `tl describe show db --json`.
- The effective rate for the last query is in `usage.credit_rate` on the response.

No CLI code change — the multiplier comes from the server in the response envelope. Per AGENTS.md, this commit logs the server-side rate change in the CLI repo's history.

## Test plan

- [ ] After server PR ships, run `tl describe show db --json` and confirm the `pg_surcharges` block is populated from `Config[cli_db_pricing]`.
- [ ] Run `tl db pg "SELECT outreach_email FROM thoughtleaders_channel LIMIT 1"` and confirm `usage.credit_rate` is higher than for a bare `SELECT id FROM thoughtleaders_sponsorship LIMIT 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)