### PR TITLE
skill: tighten tl description (David + Ivan feedback, mirror of #53)

### DIFF
--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -1,18 +1,44 @@
 ---
 name: tl
 description: |
-  Query and analyze ThoughtLeaders business data using the `tl` CLI. Default to raw database queries via `tl db pg|fb|es` for anything non-trivial (joins, aggregations, multi-condition filters, anything that would otherwise need post-processing); use the structured resource commands (sponsorships, deals, channels, brands, uploads, snapshots, reports) only for trivially simple lookups (single-record show by ID, plain filtered lists). You ARE the AI layer — do not use `tl ask`.
+  Query and analyze ThoughtLeaders business data using the `tl` CLI.
+  Default to raw database queries via `tl db pg|fb|es` for any
+  non-trivial work (joins, aggregations, multi-condition filters,
+  anything that would otherwise need post-processing); the structured
+  resource commands (sponsorships, deals, channels, brands, uploads,
+  snapshots, reports) are for trivial single-record or plain-filtered
+  lookups only. You ARE the AI layer — do not use `tl ask`.
 
-  **Use this skill for ANALYTICAL questions**: counts, metrics, trends, time-series, distributions, single-record drill-downs, revenue / pipeline-weighting math, view-curve analysis, cross-source business questions. *"How many deals did we close last quarter?"*, *"What's the weighted pipeline by sales owner?"*, *"Show me the view curve for video X"*, *"Find mentions of Surfshark in transcripts"*, *"Investigate this video"*.
-
-  **DEFER to `tl-cli:tl-report-builder`** when the user wants a **LIST of entities with filters** — channels, videos, brands, or sponsorships shaped as a report deliverable, regardless of whether they say "report" or "campaign". *"Show me partnerships from last quarter for beauty creators"*, *"Find me gaming channels with 100K+ subs"*, *"List the brands flagged as Managed Services"*, *"All sponsorships for channel X"*, *"Build me a TPP fintech list"* — every one of these goes to `tl-cli:tl-report-builder`, not here. The report-builder owns the four report types (content / brands / channels / sponsorships) and the preview/save flow; using this skill instead produces ad-hoc data dumps that bypass the saved-report system.
-
-  Quick routing test: *"would the answer to this prompt be a TL report (a list of entities I'd want to come back to)?"* — if yes, route to `tl-cli:tl-report-builder`. If no (it's a number, a chart, a single record, or an exploratory analysis), use this skill.
+  Use for analytical answers — counts, metrics, trends, single-record
+  drill-downs, cross-source business questions. For
+  list-of-entities-with-filters requests that would produce a saved
+  TL report, route to `tl-cli:tl-report-builder` instead.
 ---
 
 # ThoughtLeaders Data Analyst
 
 Run the `tl` CLI to query ThoughtLeaders' sponsorship platform data. Use it to answer questions about deals, channels, brands, uploads, metrics, etc.
+
+## When to route elsewhere
+
+This skill answers analytical / lookup questions against TL data. One adjacent skill carries a related but distinct intent — route to it instead when the user's request matches its shape:
+
+### Route to `tl-cli:tl-report-builder` (list-of-entities-with-filters as the deliverable)
+
+When the user wants **a list of channels, videos, brands, or sponsorships shaped as a TL report deliverable** — even if they don't literally say "report" or "campaign" — route to `tl-cli:tl-report-builder`. That skill owns the four report types (content / brands / channels / sponsorships) and the preview/save flow against the TL web app.
+
+Concrete examples that belong over there, not here:
+- *"Show me partnerships from last quarter for beauty creators"*
+- *"Find me gaming channels with 100K+ subs"*
+- *"List the brands flagged as Managed Services"*
+- *"All sponsorships for channel X"*
+- *"Build me a TPP fintech list"*
+
+Using this skill for those produces ad-hoc data dumps that bypass the saved-report system.
+
+### Quick routing test
+
+*"Would the answer to this prompt be a TL report — a list of entities I'd want to come back to?"* If yes, route to `tl-cli:tl-report-builder`. If no (it's a number, a chart, a single record, or an exploratory analysis), use this skill.
 
 ## Core Principles
 


### PR DESCRIPTION
**Skill content fix** — tighten the `tl-cli:tl` frontmatter description, mirror of PR #53's treatment for `tl-cli:tl-report-builder`. No version bump.

## Context

PR #53 tightened the `tl-cli:tl-report-builder` description per David and Ivan's meeting (concise / clear purpose / confirm intent before heavy actions). The `tl-cli:tl` description has the same "love of text" shape — ~280 words of enumerated examples and a redundant routing test that duplicates routing semantics from the parallel skill.

This PR applies the same treatment to `tl-cli:tl`. Ivan can iterate on either or both.

## What changed

| | Before | After |
|---|---|---|
| Description length | ~280 words, 11 lines | ~100 words, 14 lines (3 paragraphs) |
| Content shape | Purpose intro + enumerated analytical examples + enumerated "DEFER to tl-report-builder" examples + redundant routing test paragraph | Purpose statement + raw-queries contract + AI-layer rule + one-line routing-to-report-builder rule |

The new description:

```yaml
description: |
  Query and analyze ThoughtLeaders business data using the `tl` CLI.
  Default to raw database queries via `tl db pg|fb|es` for any
  non-trivial work (joins, aggregations, multi-condition filters,
  anything that would otherwise need post-processing); the structured
  resource commands (sponsorships, deals, channels, brands, uploads,
  snapshots, reports) are for trivial single-record or plain-filtered
  lookups only. You ARE the AI layer — do not use `tl ask`.

  Use for analytical answers — counts, metrics, trends, single-record
  drill-downs, cross-source business questions. For
  list-of-entities-with-filters requests that would produce a saved
  TL report, route to `tl-cli:tl-report-builder` instead.
```

Hits David's three criteria:
- **Concise** — ~100 words from ~280
- **Clear purpose** — opens with the query/analyze TL business data framing
- **Heavy-action confirmation** — N/A here since `tl` is read-only; the routing-to-`tl-cli:tl-report-builder` rule is the analog (saved-report mutation belongs there, not here)

## What didn't disappear — moved to body

The enumerated examples + the explicit routing test moved into a new `## When to route elsewhere` section in the body, right after the intro paragraph and before `## Core Principles`. Section structure:

- One paragraph framing the intent split
- Sub-section "Route to `tl-cli:tl-report-builder`" — concrete list-shaped example prompts that belong over there
- Sub-section "Quick routing test" — the verbatim test from the old description, preserved in the body

Body coverage verified for everything trimmed from the description:

| Trimmed from description | Where it lives now |
|---|---|
| Enumerated analytical example prompts (*"How many deals did we close last quarter"*, etc.) | Still in the body's existing `## Methodology` / `## Workflow` / `## Available Commands` sections — these always had concrete examples |
| Enumerated report-builder counter-examples + "DEFER" framing | Moved to new "When to route elsewhere" section |
| Quick routing test paragraph | Moved to "When to route elsewhere" → "Quick routing test" sub-section |
| "You ARE the AI layer; do not use `tl ask`" rule | **Kept in the description** — it's a single-sentence behavioral contract, not a verbose enumeration; loses meaning if buried in the body |

## Test plan

After merge + Claude Code restart:

- [ ] Analytical prompts (*"how many deals closed in Q1"*, *"weighted pipeline by AM"*) still route to `tl-cli:tl`
- [ ] List-shaped prompts (*"show me partnerships from last quarter for beauty creators"*, *"find me gaming channels with 100K+ subs"*) still route to `tl-cli:tl-report-builder` — the one-line routing rule in the new description should suffice for the harness
- [ ] No agent attempts `tl ask` (the rule is preserved verbatim in the description)
- [ ] Borderline prompts (analytical with a list flavor, e.g. *"top 10 brands by deal count"*) route appropriately based on the routing test

If a specific prompt class misroutes after this lands, the right fix is to strengthen the body's "When to route elsewhere" section rather than re-bloat the description.

## What this PR does NOT touch

- ❌ The body's existing sections (`## Core Principles`, `## Data Model & Terminology`, `## Methodology`, `## Workflow`, `## Available Commands`) — unchanged
- ❌ Trigger phrases / anti-patterns / rule lists elsewhere in the body — unchanged
- ❌ Other skills' descriptions
- ❌ No version bump

## Relationship to PR #53

PR #53 (`tl-report-builder` description) and this PR (`tl` description) are siblings — same problem, same treatment, parallel solutions. They can ship independently or together. Reviewer doesn't need to coordinate them; each PR's body is self-contained.

## Iteration path for Ivan

Same as #53 — this is a starting point for Ivan's canonical revision. Easy to iterate:

- If the routing-to-tl-report-builder one-liner is too weak on borderline prompts, pull back some of the enumerated counter-examples
- If the "raw queries > resource commands" framing reads awkward, reshape — the contract matters but the wording is flexible
- If the team wants a different body section name or location, easy to move
