### PR TITLE
pass 2: cross-skill deduplication — canonical-home enforcement

### DIFF
--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -637,7 +637,14 @@ Brand-aggregated, so the ES query is an aggregation. **`tl db es` accepts at mos
 
 Type 8 stays on Postgres because the data plane is the sponsorship deal record (relations + status + dates), not text search.
 
-**Use the denormalized view `v_adspot_brand_profiles`, not raw `thoughtleaders_adlink`.** Column catalogue + join paths + "columns that don't exist on adlink" (no direct `brand_id`/`channel_id` FKs) all live at the canonical schema home: [`tl/references/postgres-schema.md`](../tl/references/postgres-schema.md). Direct joins like `JOIN thoughtleaders_brand ON adlink.brand_id = ...` are rejected by the planner because the FK doesn't exist on adlink.
+**Use the denormalized view `v_adspot_brand_profiles`, not raw `thoughtleaders_adlink`.** The base adlink table does NOT carry `brand_id` or `channel_id` columns — those relations live on the view. Direct joins like `JOIN thoughtleaders_brand ON adlink.brand_id = ...` will be rejected by the planner because the FK doesn't exist on adlink.
+
+The view exposes one row per (adlink × brand × channel) and surfaces these columns the skill cares about:
+- `adlink_id`, `adlink_publish_status`, `adlink_created_at`, `adlink_updated_at`
+- `brand_id`, `brand_name`
+- `channel_id`, `channel_name`, `channel_msn_join_date`
+- `organization_id`, `organization_name`, `organization_is_managed_services`
+- `adlink_owner_advertiser_email`, `adlink_owner_sales_email`
 
 **Important: count and sample MUST be deduped by `adlink_id`.** The view holds one row per `(adlink × brand × channel)` — a sponsorship spanning multiple brands or channels produces multiple rows. Type-8 counts sponsorship records (AdLinks), not view rows. **Always `COUNT(DISTINCT adlink_id)` for `db_count`; dedupe samples by `adlink_id`.** Direct `COUNT(*)` overcounts multi-brand/multi-channel adlinks.
 

--- a/skills/tl-report-builder/SKILL.md
+++ b/skills/tl-report-builder/SKILL.md
@@ -637,16 +637,9 @@ Brand-aggregated, so the ES query is an aggregation. **`tl db es` accepts at mos
 
 Type 8 stays on Postgres because the data plane is the sponsorship deal record (relations + status + dates), not text search.
 
-**Use the denormalized view `v_adspot_brand_profiles`, not raw `thoughtleaders_adlink`.** The base adlink table does NOT carry `brand_id` or `channel_id` columns — those relations live on the view. Direct joins like `JOIN thoughtleaders_brand ON adlink.brand_id = ...` will be rejected by the planner because the FK doesn't exist on adlink.
+**Use the denormalized view `v_adspot_brand_profiles`, not raw `thoughtleaders_adlink`.** Column catalogue + join paths + "columns that don't exist on adlink" (no direct `brand_id`/`channel_id` FKs) all live at the canonical schema home: [`tl/references/postgres-schema.md`](../tl/references/postgres-schema.md). Direct joins like `JOIN thoughtleaders_brand ON adlink.brand_id = ...` are rejected by the planner because the FK doesn't exist on adlink.
 
-The view exposes one row per (adlink × brand × channel) and surfaces these columns the skill cares about:
-- `adlink_id`, `adlink_publish_status`, `adlink_created_at`, `adlink_updated_at`
-- `brand_id`, `brand_name`
-- `channel_id`, `channel_name`, `channel_msn_join_date`
-- `organization_id`, `organization_name`, `organization_is_managed_services`
-- `adlink_owner_advertiser_email`, `adlink_owner_sales_email`
-
-**Important: count and sample MUST be deduped by `adlink_id`.** The view holds one row per `(adlink × brand × channel)` — a single sponsorship that involves multiple brands or multiple channel relations produces multiple rows. Type-8 reports count sponsorship records (AdLinks), not view rows. **Always use `COUNT(DISTINCT adlink_id)` for `db_count` and dedupe samples by `adlink_id`.** A globally-confirmed 184 view rows correspond to fewer underlying adlinks — direct `COUNT(*)` overcounts those cases.
+**Important: count and sample MUST be deduped by `adlink_id`.** The view holds one row per `(adlink × brand × channel)` — a sponsorship spanning multiple brands or channels produces multiple rows. Type-8 counts sponsorship records (AdLinks), not view rows. **Always `COUNT(DISTINCT adlink_id)` for `db_count`; dedupe samples by `adlink_id`.** Direct `COUNT(*)` overcounts multi-brand/multi-channel adlinks.
 
 ##### Filter predicate mapping (must mirror the saved FilterSet)
 

--- a/skills/tl-report-builder/references/report_glossary.md
+++ b/skills/tl-report-builder/references/report_glossary.md
@@ -42,7 +42,16 @@ Quick **FilterSet-mapping reference** (where these business terms appear in the 
 | **TL profit** | Custom formula `{Price} - {Cost}` (NOT "margin" — see glossary) |
 | **Sold sponsorship / Match / Proposal / Deal** | `filters_json.publish_status` (see "Deal-stage jargon" below for ID mapping) |
 
-For **industry terms NOT used at TL** (flight, hero, margin, impressions, etc.) — translation table lives in `business-glossary.md` "Industry Terms vs TL Vocabulary". Mirror the user's language in clarifying questions; emit TL terms in the config.
+### Industry terms — DON'T emit in config
+
+Industry-default terms that don't translate; never put in field names, formulas, columns, or user-facing copy:
+
+- ❌ **"flight"** (MarTech) → say "campaign" or "date range" (full flight-variant translation lives in [`business-glossary.md`](../../tl/references/business-glossary.md) "Industry Terms vs TL Vocabulary")
+- ❌ **"hero / hero-tier / hero channel"** → say "high-priority" or "TPP" if appropriate
+- ❌ **"margin"** (accounting) → say `Net revenue` or `TL profit`
+- ❌ **"impressions"** in YouTube context → say `Views` or `Projected Views`
+
+Mirror the user's language in the *clarifying question*; emit TL terms in the config.
 
 ## Deal-stage jargon (type 8)
 

--- a/skills/tl-report-builder/references/report_glossary.md
+++ b/skills/tl-report-builder/references/report_glossary.md
@@ -22,38 +22,27 @@ Phase 1 + 2 disambiguation: report-type synonyms, TL terminology, field-pair cho
 | **"pipeline"** *(no other context)* | Type 8 with active-stage filter | Default to type 8; confirm. |
 | **"book of business"** | Type 8 with `tl_sponsorships_only: true` | Default to type 8 + filter; confirm scope. |
 
-### TL role / pool synonyms
+### TL role / pool synonyms + TL terminology
 
-| Term | Meaning | Where it shows up |
-|---|---|---|
-| **MSN** | Media Selling Network — broad ~11K opted-in channel pool | `msn_channels_only` |
-| **TPP** | ThoughtLeaders Premier Partners — smaller ~169 high-touch managed pool. **Resolve-and-pin pattern**: `SELECT id FROM thoughtleaders_channel WHERE is_tl_channel = TRUE AND is_active = TRUE ORDER BY id` → put IDs in `filterset.channels`. TPP IS a recognized filter; the implementation detail is resolve-and-pin. | `is_tl_channel = TRUE` resolved → `filterset.channels` |
-| **MBN** | Media Buying Network — managed-services advertisers | `cross_references` type `include_sponsored_by_mbn` |
-| **AM** / **Account Manager** | Advertiser-side deal owner | `owner_advertiser_name` (in `filters_json` for type 8) |
-| **TM** / **Talent Manager** / **Publisher Manager** | Publisher-side deal owner | `owner_publisher_name` (in `filters_json` for type 8) |
+> **Canonical source**: [`tl/references/business-glossary.md`](../../tl/references/business-glossary.md) — the canonical home for TL business terminology (MSN, TPP, MBN, AM/TM ownership, View Guarantees, Net revenue, TL profit, performance grade, industry-vs-TL vocabulary translations). Do NOT redefine these terms here; this skill defers to the glossary.
 
-## TL terminology — use these
+Quick **FilterSet-mapping reference** (where these business terms appear in the report-builder context — for full definitions see the canonical glossary):
 
-| Term | Meaning | Where it shows up |
-|---|---|---|
-| **Reach** | TL's rolling audience-size metric (not raw YouTube subs) | `reach_from` / `reach_to` |
-| **Projected Views (PV)** | Pricing estimate for next video; drives sponsorship pricing | `projected_views_from` / `projected_views_to`; column `Projected Views` |
-| **View Guarantee (VG)** | Contractual floor on views for a deal. Type-8 only. | Type 8 columns: `Views Guaranteed`, `Views Guarantee Days` |
-| **Net revenue** | TL's earned revenue. NOT "margin." | Type 8 column: `Revenue` |
-| **TL profit** | `Price - Cost`. NOT "margin." | Custom formula `{Price} - {Cost}` |
-| **Sold sponsorship** | Contractually agreed deal | Type 8 `filters_json.publish_status` |
-| **Match / Proposal / Deal** | Funnel: Match (possible) → Proposal (offered) → Deal (sold) | `filters_json.publish_status` for type 8 |
+| Term | FilterSet / `filters_json` mapping in this skill |
+|---|---|
+| **MSN** | `msn_channels_only: true` |
+| **TPP** | resolve-and-pin pattern — `SELECT id FROM thoughtleaders_channel WHERE is_tl_channel = TRUE AND is_active = TRUE ORDER BY id` → put IDs in `filterset.channels` |
+| **MBN** | `cross_references` type `include_sponsored_by_mbn` |
+| **AM** / Account Manager | `owner_advertiser_name` (in `filters_json` for type 8) |
+| **TM** / Talent Manager | `owner_publisher_name` (in `filters_json` for type 8) |
+| **Reach** | `reach_from` / `reach_to` (narrate as "subscribers" per business-glossary) |
+| **Projected Views (PV)** | `projected_views_from` / `projected_views_to`; column `Projected Views` |
+| **View Guarantee (VG)** | Type 8 columns: `Views Guaranteed`, `Views Guarantee Days` |
+| **Net revenue** | Type 8 column: `Revenue` |
+| **TL profit** | Custom formula `{Price} - {Cost}` (NOT "margin" — see glossary) |
+| **Sold sponsorship / Match / Proposal / Deal** | `filters_json.publish_status` (see "Deal-stage jargon" below for ID mapping) |
 
-## TL terminology — DON'T use
-
-Industry-default terms that don't translate; never put in field names, formulas, columns, or user-facing copy:
-
-- ❌ **"flight"** (MarTech) → say "campaign" or "date range"
-- ❌ **"hero / hero-tier / hero channel"** → say "high-priority" or "TPP" if appropriate
-- ❌ **"margin"** (accounting) → say `Net revenue` or `TL profit`
-- ❌ **"impressions"** in YouTube context → say `Views` or `Projected Views`
-
-Mirror the user's language in the *clarifying question*; emit TL terms in the config.
+For **industry terms NOT used at TL** (flight, hero, margin, impressions, etc.) — translation table lives in `business-glossary.md` "Industry Terms vs TL Vocabulary". Mirror the user's language in clarifying questions; emit TL terms in the config.
 
 ## Deal-stage jargon (type 8)
 
@@ -71,7 +60,7 @@ Map informal descriptions → `filters_json.publish_status` IDs (integer; platfo
 | **"in progress"** / **"active"** | `0, 2, 3, 6` | — | Active incl. sold |
 | **"live"** / **"currently running"** | `3` | `ad_publish_status: "0"` | Sold AND published |
 
-Status reference: `0` Creator Approved, `1` Unavailable, `2` Pending, `3` Sold, `4` Rejected by Brand, `5` Rejected by Creator, `6` Proposal Approved, `7` Matched, `8` Reached Out, `9` Rejected by Agency.
+Full `publish_status` enum (all 12 codes incl. CLIENT_SIDE_* and pipeline weights) lives at the canonical schema home: [`tl/references/postgres-schema.md` → `publish_status` Constants](../../tl/references/postgres-schema.md#publish_status-constants). The NL → ID mapping above is what this skill consumes; refer to the schema doc for the full enum and Django-side constants.
 
 ## Field-pair disambiguation
 


### PR DESCRIPTION
**Branched off pass 1's branch** (`nerya/pass1-skill-compression`), so this PR's diff includes pass 1's compression work + this PR's dedup work on top. When pass 1 (PR #55) merges, this PR rebases onto main cleanly with just the dedup commits.

## Background

Pass 1 was compression. Pass 2 is **canonical-home enforcement** — when the same business fact or schema fact lives in both skills, keep it in `tl-cli:tl`'s `references/` (the canonical home per AGENTS.md "Skill content boundaries") and replace the duplicate in `tl-cli:tl-report-builder` with a cross-link.

Same pattern PR #25 / #31 used for the topics-table fetch — generalized across more facts.

## Items addressed

| # | Duplication | Canonical home | Result | Status |
|---|---|---|---|---|
| 1 | **MSN / TPP / MBN definitions** | `business-glossary.md` "MSN" + Entities + Ownership | Replaced `report_glossary.md` table rows with FilterSet-mapping reference + cross-link | ✅ Resolved |
| 2 | **TL terminology** (Reach, PV, VG, Net revenue, TL profit, Sold sponsorship, Match/Proposal/Deal) | Same canonical home | Merged into FilterSet-mapping table; cross-link to business-glossary | ✅ Resolved |
| 3 | **Industry terms — DON'T use** (flight, hero, margin, impressions) | `business-glossary.md` "Industry Terms vs TL Vocabulary" | **Partial**: `flight` cross-linked (canonical covers it). `hero / margin / impressions` restored inline (canonical doesn't cover them yet). | 🟡 Partial — see fix commit |
| 4 | **`publish_status` status reference table** (all 10 IDs + names) | `postgres-schema.md` `publish_status` Constants section | Replaced inline 10-status list with cross-link; kept the NL→ID mapping table (skill-shaped — user language → backend IDs) | ✅ Resolved |
| 5 | **`v_adspot_brand_profiles` view column catalogue** | `postgres-schema.md` | **Reverted**: canonical file does not document this view; column catalogue restored inline. | ❌ Reverted — see fix commit |

## Review-feedback fix (commit `eab78ad`)

A review of this PR caught two cross-links that pointed at content the canonical files did not actually contain:

- **Finding 1** — `postgres-schema.md` has no `v_adspot_brand_profiles` documentation, so the SKILL.md cross-link (item 5) removed load-bearing query guidance without moving it. Fix: restored the 5-line column catalogue inline.
- **Finding 2** — `business-glossary.md`'s "Industry Terms vs TL Vocabulary" only documents flight variants — no `hero`, `margin`, or `impressions` rows. Fix: kept `flight` as a cross-link, restored explicit DON'T-use rules for `hero / margin / impressions` inline.

Moving these fully to the canonical home is the right long-term shape but requires an upstream sync to `thoughtleaders-skills/tl-data/references/` that is out of scope for pass 2. Pass 3 can revisit when there's appetite for upstream sync.

## Diff scope (post-fix)

| File | vs pass 1 tip |
|---|---|
| `skills/tl-report-builder/SKILL.md` | +2 lines (deduped some prose; restored v_adspot_brand_profiles columns) |
| `skills/tl-report-builder/references/report_glossary.md` | -2 lines (deduped MSN/TPP/TL-terminology rows; restored hero/margin/impressions inline) |

Token savings are smaller than checkpoint 1's optimistic estimate (~700 → ~300) due to the review-feedback restoration. The maintenance win still holds for items 1, 2, and 4 — those facts now have a single source of truth.

## What stays in `tl-report-builder`

| Content | Why it stays here, not in `tl` |
|---|---|
| The **NL → `publish_status` ID mapping table** (deal-stage jargon) | Skill-shaped — translates user language ("sold", "live", "in pipeline") to backend integers. Not a schema fact. |
| The **FilterSet-mapping reference table** for TL terms (MSN → `msn_channels_only`, etc.) | Skill-shaped — maps business terms to specific FilterSet fields. Not a definition. |
| The **`v_adspot_brand_profiles` column catalogue** (post-fix) | Reverted from cross-link — canonical schema doc doesn't cover this view yet. Restoring full ownership to canonical is pass-3 / upstream-sync work. |
| The **`hero / margin / impressions` DON'T-use rules** (post-fix) | Reverted from cross-link — canonical glossary only covers flight variants. Same pass-3 / upstream-sync caveat. |
| The **dedupe-by-adlink_id rule** | Skill-shaped — operational guidance for the validation query. Not schema. |

## Out of scope (deferred)

- **Item 6 (Reach/Subscribers consolidation)** — the narration rule in SKILL.md rule 7 is already a cross-reference to business-glossary; not actually duplicated.
- **Item 8 (save-mode narration rules → migration to `tl-cli:tl`)** — pass 3 territory per exploration-vs-save split.
- **More schema-content extraction** from SKILL.md Phase 2 (filter predicate mapping, date-scope mapping, bounds materialization) — primarily skill-shaped query templates, not schema catalog.
- **Adding `v_adspot_brand_profiles` and the hero/margin/impressions rows to canonical files** — requires upstream sync; deferred to pass 3 or follow-up.

## Test plan after merge

- [ ] Renaming TPP / adjusting MSN definition / adding a `publish_status` code requires only one file edit (in `tl/references/`) — `tl-report-builder` automatically picks up the change via the cross-link (items 1, 2, 4)
- [ ] Agent still produces correct FilterSets for TPP / MSN / VG-related prompts (the FilterSet-mapping table preserves the skill-relevant pointers)
- [ ] Agent still emits valid type-8 validation SQL using `v_adspot_brand_profiles` columns (restored inline post-fix)
- [ ] Agent still avoids `hero / margin / impressions` in narrated output (restored inline post-fix)

## Stack status

| | State |
|---|---|
| PR #55 (pass 1 — compression) | ✅ Ready for review |
| **This PR (pass 2 — dedup)** | 🟡 Open, builds on pass 1; 1 checkpoint + 1 review-fix commit |
| Pass 3 (architectural refactor per  exploration + save split) | 📋 Planned, after passes 1 + 2 merge |

No version bump (tracked separately).