### PR TITLE
db fb/es: --pricing flag + generalized estimate renderer

### DIFF
--- a/API.md
+++ b/API.md
@@ -237,6 +237,8 @@ Send `{"query": "…", "pricing": true}` to `POST /raw/pg` (CLI: `tl db pg "…"
 
 `multiplier` and `per_row_extra` are exact; `estimated_cost_at_limit` is an **upper bound** computed at the query's effective `LIMIT` (the query can't return more rows than that). A dry run costs a flat **1 credit**.
 
+The same `{"pricing": true}` flag works on `POST /raw/fb` and `POST /raw/es`. Those backends are flat-rate (no per-table/column extras), so the estimate carries `multiplier` = the backend rate, `per_row_extra` = 0, empty expensive-item maps, and `limit` = the row ceiling (Firebolt `LIMIT`; Elasticsearch `size`, or the aggregation doc cap for agg queries). A Firebolt query with no `LIMIT` returns `limit`/`estimated_cost_at_limit` as `null` (unbounded). No query executes; flat 1 credit.
+
 ### Common rejections
 
 - `MISSING_LIMIT` / `LIMIT_TOO_HIGH` — always include `LIMIT N` with `N ≤ 10,000`.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ tl balance                                 # Your credit balance
 
 `tl db pg` is priced **per-query**: a base rate plus a multiplier extra for every expensive table referenced, plus a flat per-row charge for every expensive column read. Sensitive fields (demographics, channel outreach emails) are expensive. Run `tl describe show db --json` to see the live `pg_expensive` map, and check `usage.credit_rate` in the response envelope after a query to see what your query was actually charged.
 
-To preview a query's cost **before** running it, add `--pricing`: `tl db pg "SELECT … LIMIT 100" --pricing` runs only the planner's `EXPLAIN`, prints the cost breakdown and an upper-bound estimate (at the query's `LIMIT`), and costs a flat **1 credit** — the query itself never executes. Works with `--json` too.
+To preview a query's cost **before** running it, add `--pricing`: `tl db pg "SELECT … LIMIT 100" --pricing` runs only the planner's `EXPLAIN`, prints the cost breakdown and an upper-bound estimate (at the query's `LIMIT`), and costs a flat **1 credit** — the query itself never executes. Works with `--json` too. `--pricing` is also available on `tl db fb` and `tl db es`; those backends are flat-rate (no per-column charges), so the estimate is the volume curve at the query's row ceiling (`LIMIT` for Firebolt, `size` — or the aggregation doc cap — for Elasticsearch).
 
 # Terminology
 

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -399,7 +399,7 @@ If unsure about what information to find where, read the [references/postgresql-
 
 **PG cost is per-query.** The credit cost for a `tl db pg` call is a base rate plus a multiplier extra for every expensive table referenced, plus a **flat per-row charge** for every expensive column read (an expensive column costs its configured value for every row returned). Most tables and columns are not expensive; sensitive ones (e.g. demographics, channel outreach emails) cost more. Run `tl describe show db --json` to see the live `pg_expensive` map, and check `usage.credit_rate` / `usage.pricing` in the response envelope after a query to see what your query was actually charged.
 
-**Preview cost before running.** Add `--pricing` to estimate a query's cost without executing it: `tl db pg "SELECT … LIMIT 100" --pricing` runs only `EXPLAIN`, prints the multiplier + per-row breakdown and an upper-bound cost (at the query's LIMIT), and costs a flat 1 credit. Use this before large or expensive-column queries. Works with `--json`.
+**Preview cost before running.** Add `--pricing` to estimate a query's cost without executing it: `tl db pg "SELECT … LIMIT 100" --pricing` runs only `EXPLAIN`, prints the multiplier + per-row breakdown and an upper-bound cost (at the query's LIMIT), and costs a flat 1 credit. Use this before large or expensive-column queries. Works with `--json`. `--pricing` also works on `tl db fb` and `tl db es` — those backends have no per-column charges, so the estimate is just the volume curve at the row ceiling (`LIMIT` for Firebolt; `size`, or the aggregation doc cap, for Elasticsearch).
 
 ### Three sources, each authoritative for different things
 

--- a/src/tl_cli/commands/db.py
+++ b/src/tl_cli/commands/db.py
@@ -7,7 +7,7 @@ import typer
 
 from tl_cli.client.errors import ApiError, handle_api_error
 from tl_cli.client.http import get_client
-from tl_cli.output.formatter import detect_format, output, output_pg_pricing_estimate
+from tl_cli.output.formatter import detect_format, output, output_pricing_estimate
 
 app = typer.Typer(help="Raw read-only queries against PostgreSQL, Firebolt, or Elasticsearch (full-access only)")
 
@@ -25,7 +25,7 @@ def _run(path: str, body: dict, fmt: str, title: str, pricing: bool = False) -> 
     try:
         data = client.post(path, json_body=body)
         if pricing:
-            output_pg_pricing_estimate(data, fmt)
+            output_pricing_estimate(data, fmt)
             return
         output(data, fmt, title=title)
         aggs = data.get("aggregations")
@@ -75,6 +75,10 @@ def fb_cmd(
     csv_output: bool = typer.Option(False, "--csv", help="CSV output"),
     md_output: bool = typer.Option(False, "--md", help="Markdown output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output"),
+    pricing: bool = typer.Option(
+        False, "--pricing",
+        help="Estimate the query's credit cost without running it (flat 1 credit).",
+    ),
 ) -> None:
     """Run a raw Firebolt SELECT query.
 
@@ -86,7 +90,10 @@ def fb_cmd(
     """
     fmt = detect_format(json_output, csv_output, md_output, toon_output)
     sql = _read_query(query)
-    _run("/raw/fb", {"query": sql}, fmt, "Firebolt results")
+    body: dict = {"query": sql}
+    if pricing:
+        body["pricing"] = True
+    _run("/raw/fb", body, fmt, "Firebolt results", pricing=pricing)
 
 
 @app.command("es")
@@ -96,6 +103,10 @@ def es_cmd(
     csv_output: bool = typer.Option(False, "--csv", help="CSV output"),
     md_output: bool = typer.Option(False, "--md", help="Markdown output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output"),
+    pricing: bool = typer.Option(
+        False, "--pricing",
+        help="Estimate the query's credit cost without running it (flat 1 credit).",
+    ),
 ) -> None:
     """Run a raw Elasticsearch search query.
 
@@ -112,4 +123,7 @@ def es_cmd(
     except json.JSONDecodeError as exc:
         raise typer.BadParameter(f"Query is not valid JSON: {exc}") from exc
 
-    _run("/raw/es", {"query": body_query}, fmt, "Elasticsearch results")
+    body: dict = {"query": body_query}
+    if pricing:
+        body["pricing"] = True
+    _run("/raw/es", body, fmt, "Elasticsearch results", pricing=pricing)

--- a/src/tl_cli/output/formatter.py
+++ b/src/tl_cli/output/formatter.py
@@ -529,14 +529,20 @@ def _print_quota_notice(data: dict) -> None:
         )
 
 
-def output_pg_pricing_estimate(data: dict, fmt: str) -> None:
-    """Render the `--pricing` dry-run estimate for `tl db pg`.
+def output_pricing_estimate(data: dict, fmt: str) -> None:
+    """Render the `--pricing` dry-run estimate for `tl db pg|fb|es`.
 
     The server returns a `pricing_estimate` block (no `results`) plus the
     usual `usage` footer reflecting the flat dry-run charge. JSON mode
     dumps the whole envelope; table mode prints a headline cost line, the
     multiplier / per-row split, and a breakdown of the expensive items
     the query touches.
+
+    Firebolt and Elasticsearch have no per-column extras — their estimate
+    carries `per_row_extra=0` and empty expensive-item maps, so the
+    breakdown table is skipped and only the volume-curve cost shows.
+    A `limit`/cost of `None` (e.g. a Firebolt query with no `LIMIT`) means
+    the row count is unbounded and the cost can't be pinned ahead of time.
     """
     if fmt == "json":
         print(_dump_json(data))
@@ -552,11 +558,16 @@ def output_pg_pricing_estimate(data: dict, fmt: str) -> None:
     per_row = est.get("per_row_extra")
     planner_rows = est.get("planner_estimated_rows")
 
-    console.print("[bold]PG query cost estimate[/bold] [dim](query not run)[/dim]")
-    if cost is not None:
+    console.print("[bold]Query cost estimate[/bold] [dim](query not run)[/dim]")
+    if cost is not None and limit is not None:
         console.print(
             f"  Estimated cost: [bold yellow]up to {_fmt_credits(cost)} credits[/bold yellow] "
-            f"at LIMIT {limit} row(s)"
+            f"at {limit} row(s)"
+        )
+    else:
+        console.print(
+            "  Estimated cost: [yellow]depends on rows returned[/yellow] "
+            "(no row limit set — cost scales with the volume curve)"
         )
     console.print(f"  Multiplier (base + expensive tables): {multiplier}")
     console.print(f"  Per-row extra (expensive columns):    {per_row}")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -373,7 +373,7 @@ class TestQuotaNotice:
 
 
 class TestPgPricingEstimate:
-    """`output_pg_pricing_estimate` renders the --pricing dry-run result."""
+    """`output_pricing_estimate` renders the --pricing dry-run result."""
 
     _SAMPLE = {
         "pricing_estimate": {
@@ -394,12 +394,12 @@ class TestPgPricingEstimate:
     }
 
     def test_table_mode_renders_headline_and_breakdown(self, capsys):
-        from tl_cli.output.formatter import output_pg_pricing_estimate
-        output_pg_pricing_estimate(self._SAMPLE, "table")
+        from tl_cli.output.formatter import output_pricing_estimate
+        output_pricing_estimate(self._SAMPLE, "table")
         out = capsys.readouterr().out
-        assert "PG query cost estimate" in out
+        assert "Query cost estimate" in out
         assert "28,140.26" in out
-        assert "LIMIT 100" in out
+        assert "100 row(s)" in out
         assert "4.4" in out          # multiplier
         assert "280" in out          # per-row extra
         assert "thoughtleaders_channel.outreach_email" in out
@@ -408,8 +408,8 @@ class TestPgPricingEstimate:
 
     def test_json_mode_dumps_full_envelope(self, capsys):
         import json
-        from tl_cli.output.formatter import output_pg_pricing_estimate
-        output_pg_pricing_estimate(self._SAMPLE, "json")
+        from tl_cli.output.formatter import output_pricing_estimate
+        output_pricing_estimate(self._SAMPLE, "json")
         out = capsys.readouterr().out
         parsed = json.loads(out)
         assert parsed["pricing_estimate"]["multiplier"] == 4.4
@@ -419,15 +419,15 @@ class TestPgPricingEstimate:
 
     def test_json_mode_credits_footer_on_stderr_not_stdout(self, capsys):
         import json
-        from tl_cli.output.formatter import output_pg_pricing_estimate
-        output_pg_pricing_estimate(self._SAMPLE, "json")
+        from tl_cli.output.formatter import output_pricing_estimate
+        output_pricing_estimate(self._SAMPLE, "json")
         captured = capsys.readouterr()
         # stdout must be pure JSON (no usage banner) so `| jq` works.
         json.loads(captured.out)
         assert "credits" in captured.err
 
     def test_empty_expensive_items_still_renders_headline(self, capsys):
-        from tl_cli.output.formatter import output_pg_pricing_estimate
+        from tl_cli.output.formatter import output_pricing_estimate
         data = {
             "pricing_estimate": {
                 "base": 1.4, "multiplier": 1.4, "per_row_extra": 0.0,
@@ -437,7 +437,24 @@ class TestPgPricingEstimate:
             },
             "results": [], "usage": {"credits_charged": 1},
         }
-        output_pg_pricing_estimate(data, "table")
+        output_pricing_estimate(data, "table")
         out = capsys.readouterr().out
-        assert "PG query cost estimate" in out
+        assert "Query cost estimate" in out
         assert "3.8" in out
+
+    def test_flat_backend_no_limit_says_depends_on_rows(self, capsys):
+        # Firebolt query with no LIMIT → unbounded → no cost figure.
+        from tl_cli.output.formatter import output_pricing_estimate
+        data = {
+            "pricing_estimate": {
+                "base": 1.4, "multiplier": 1.4, "per_row_extra": 0.0,
+                "expensive_tables": {}, "expensive_columns": {},
+                "limit": None, "planner_estimated_rows": None,
+                "estimated_cost_at_limit": None,
+            },
+            "results": [], "usage": {"credits_charged": 1},
+        }
+        output_pricing_estimate(data, "table")
+        out = capsys.readouterr().out
+        assert "Query cost estimate" in out
+        assert "depends on rows returned" in out


### PR DESCRIPTION
## Summary

Client side of the server's `--pricing` support for the Firebolt and Elasticsearch raw-query endpoints (server PR: ThoughtLeaders-io/thoughtleaders#4038).

- `tl db fb "… LIMIT 25" --pricing` and `tl db es '{"size":5,…}' --pricing` now estimate a query's credit cost without running it (flat 1 credit), matching the existing `tl db pg --pricing`.
- The estimate renderer is generalized to all three backends:
  - `output_pg_pricing_estimate` → `output_pricing_estimate`; header drops the "PG" prefix.
  - An unbounded estimate (no row limit — e.g. a Firebolt query with no `LIMIT`) renders "depends on rows returned" instead of a number.
  - FB/ES estimates have no per-column charges, so the breakdown table is skipped and only the volume-curve cost shows.
- Works with `--json` (estimate envelope to stdout, usage footer to stderr).

## Test plan

- [x] `tests/test_output.py` — rename coverage, table + json render, unbounded case ("depends on rows returned"), empty-expensive-items case. Suite 112/112.
- [ ] Against a deployed server with #4038: `tl db fb "SELECT … LIMIT 25" --pricing`, `tl db es '{"size":5,…}' --pricing`, and an aggregation ES query — confirm the rendered ceiling and flat 1-credit charge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
