### PR TITLE
Add tl-views-guarantee skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ This repo is also a Claude Code plugin, and can directly be installed as one.
 
 - **`tl`** — the main skill for querying ThoughtLeaders data. Default for any sponsorship / channel / brand / upload / report question.
 - **`tl-keyword-research`** — invoke whenever the user wants to find videos or channels by **content keywords** (topics, concepts, niches) that aren't covered by a curated recommender tag, OR to validate that a candidate channel's content actually touches a given topic. Returns `{operator, keywords:[{keyword,count}]}` from a ranked ES probe over `title` / `summary` / `transcript`; the caller then runs the actual content search with the surviving high-count terms. **Do not compose keyword sets by hand for `tl db es` content searches — delegate to this skill first.** See `skills/tl/SKILL.md` → *Channel & video discovery* for the four-path decision tree and when to use this vs the recommender / raw SQL.
-- **`tl-import`**, **`tl-save-report`**, **`adapt-tl-data`** — narrower workflows; the skill files document their own triggers.
+- **`tl-import`**, **`tl-save-report`**, **`adapt-tl-data`**, **`tl-views-guarantee`** — narrower workflows; the skill files document their own triggers.
 
 ### Skill content boundaries
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The plugin ships several focused skills (installed by all the `tl setup *` comma
 - **`tl`** — the data-analyst skill. Defaults to raw database queries via `tl db pg|fb|es` for anything non-trivial; uses the structured `tl <resource> show` / `find` / `similar` commands for single-record lookups and similarity / ID-resolution special cases. Comes with full schema references for Postgres, Elasticsearch, and Firebolt under `references/`.
 - **`tl-report-builder`** — builds TL reports (channels / brands / sponsorships / videos) from natural-language requests. Produces an in-chat preview by default; saves a real campaign when the user is explicit ("save", "create the report").
 - **`tl-import`** / **`bulk-import`** — superuser-only; bulk-add or exclude lists of channels, brands, videos, or sponsorships against a report.
+- **`tl-views-guarantee`** — sizes a multi-video sponsorship buy for a channel, returning the video bundle size, views guarantee, and likelihood to hit.
 
 ## Output Formats
 

--- a/skills/tl-views-guarantee/SKILL.md
+++ b/skills/tl-views-guarantee/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: tl-views-guarantee
+description: Calculate the optimal views guarantee (VG) for a multi-video sponsorship buy with a YouTube creator. Given a channel ID or name, returns "video bundle size / views guarantee / likelihood to hit" based on bootstrap simulation of the channel's recent video performance (view counts measured at video age ~30 days). Use when someone asks "what VG should I push for with [creator]", "how many videos should I buy from [creator]", "calculate VG for [channel]", "what's a safe guarantee for [channel]", or anything involving setting views guarantees in a sponsorship deal. Triggers on "VG", "views guarantee", "views minimum", and any request to size a multi-video buy.
+---
+
+# Views Guarantee (VG) Calculator
+
+Runs a single script and returns one answer.
+
+## Usage
+
+User says:
+- "What VG should I push for with Sydney Watson?"
+- "Calculate VG for channel 20107"
+- "How many videos should I buy from Stephen Gardner?"
+
+**Default path — this is what you do almost every time.** Run the script with just the channel ID or name, no flags (`<SKILL_DIR>` is this skill's directory):
+
+```bash
+python3 <SKILL_DIR>/scripts/vg.py <channel_id_or_name>
+```
+
+Print the script's four-line output back to the user verbatim — don't reformat it into a table, add commentary, or pull in extra metrics. Then, in one short line, offer to go deeper (e.g. "Want the full bundle-size sweep, a larger buy, or the per-video / cadence breakdown?"). Keep the first answer minimal; only reach for the flags below when the user actually asks for more. Don't volunteer them by running them speculatively.
+
+### Optional flags — only when the user explicitly asks for more
+
+Add these **one at a time, matched to what the user requested** — never stack them by default:
+
+- `--sweep`: the user wants to see every bundle size, not just the recommendation. Prints the recommendation followed by the full table.
+- `--max-bundle-size N`: the user is considering a larger / long-term buy (5+ videos). Raises the ceiling from the default `4` up to `10`.
+- `--target max`: the user (or the brand) prefers the biggest bundle that still clears the threshold rather than the smallest. Pair with a raised `--max-bundle-size` to actually pick a larger buy. (`--target min` is the default and need not be passed.)
+- `--rich-output`: the user wants the extra economics — `Per-video VG`, `Upload cadence` (longform uploads per month), and `Campaign length` (≈ bundle size ÷ cadence). In sweep mode it also adds `Campaign length` and `VG/video` table columns plus `Projected views` / `Sample size` / `Sample window` context lines.
+- `--full-range`: only when the script itself printed an **INCONSISTENT RESULTS** banner suggesting it — forces the sample to the full 30–240d window instead of the staircase.
+
+## What the script does
+
+1. Resolves channel ID from name if needed (via `tl channels find <name>`)
+2. Pulls `projected_views` from the channel record
+3. Picks a sample window matching the range used for the channel's projected views: primary is **videos published 30–90 days ago**; if fewer than 5 videos survive, widens to **30–120**, then **30–180**, then **30–240**. Never samples beyond 240 days (the outer bound of that range).
+4. Looks up each video's view count at age 28–32 days
+5. Bootstrap-simulates 10k buys for each video bundle size from 1 up to `--max-bundle-size` (default 4, configurable up to 10)
+6. For each bundle size: `VG = max(0.75 × bundle_size × projected_views, p20 of bootstrap totals)`
+7. With `--target min` (default), picks the smallest bundle size whose likelihood ≥ 80%. With `--target max`, picks the largest such bundle, capped at `--max-bundle-size`.
+8. If no bundle size hits 80%, falls back to the closest match: highest likelihood for `--target min`, largest bundle for `--target max`. The result is reported with its actual (sub-80%) likelihood as a negotiation signal.
+9. If the sample came from anything other than the primary 30–90d window, prints a **FALLBACK WINDOW** banner — the bootstrap reflects older performance than the projected-views baseline, so treat the result as less current.
+10. If the primary sample is **thin** (fewer than 10 videos) and the staircase didn't already use the widest window, the script silently re-runs the bootstrap against the full 30–240d sample and compares. If the two results disagree on the chosen bundle size, on whether they reach the 80% likelihood threshold, or by ≥10% on VG, it prints an **INCONSISTENT RESULTS** banner suggesting you re-run with `--full-range` to inspect the wider view.
+
+## Output format
+
+**This is the default and the only output you produce unless the user asks for more.** Four lines — relay them as-is:
+
+```
+Channel: Sydney Watson (20107)
+Video bundle size: 2
+Views guarantee: 536,422
+Likelihood to hit: 80%
+```
+
+<details>
+<summary>What the optional flags add (only render these when the user asked for them)</summary>
+
+`--sweep` — recommendation block first, then the full table with the chosen row marked `←`:
+
+```
+Channel: Sydney Watson (20107)
+Video bundle size: 2
+Views guarantee: 536,422
+Likelihood to hit: 80%
+
+Bundle size            VG  Likelihood
+          1       257,989        71%
+          2       536,422        80%  ←
+          3       841,851        80%
+          4     1,166,196        80%
+```
+
+`--sweep --rich-output --max-bundle-size 10 --target max` — adds the per-bundle rich detail (`Per-video VG`, `Upload cadence`, `Campaign length`), the `Projected views` / `Sample size` / `Sample window` context lines under `Likelihood to hit`, and two extra table columns (`Campaign length` after `Bundle size`, `VG/video` between `VG` and `Likelihood`):
+
+```
+Channel: Sydney Watson (20107)
+Video bundle size: 10
+Views guarantee: 3,109,269
+Likelihood to hit: 80%
+Projected views: 343,986
+Sample size: 14 videos
+Sample window: 30-90d
+Per-video VG: 310,926
+Upload cadence: 6.2/month
+Campaign length: ~1.6 months
+
+Bundle size  Campaign length            VG    VG/video  Likelihood
+          1      ~0.2 months       257,989     257,989        71%
+          2      ~0.3 months       536,422     268,211        80%
+          ...
+         10      ~1.6 months     3,109,269     310,926        80%  ←
+```
+
+</details>
+
+## Edge cases
+
+- **<5 historical samples**: skill exits with `insufficient data — only <count> videos with 30-day view data (need 5+)`.
+- **5-9 samples**: prints `⚠️  THIN SAMPLE: only <count> videos — bootstrap variance is high, treat result as approximate.` underneath the result.
+- **No projected_views on the channel record**: usually means the channel hasn't published enough content to establish a baseline (not a data staleness issue). Statistical VG isn't available — fall back on your own judgement.
+- **Volatile/underperforming creators**: the skill reports the floor VG with whatever likelihood the data supports (could be 60–70%). A lower likelihood isn't a failure — treat it as a negotiation signal. A missed guarantee typically just means the creator owes a make-good video, so a guarantee you're comfortable accepting at lower confidence can still be the right call.
+
+## Methodology notes
+
+- Floor: `0.75 × bundle_size × projected_views` (the 75% rule, aggregate)
+- Skew adjustment: `max(floor, p20 of bootstrap)` — the bootstrap p20 will exceed the floor only when the channel has tight distribution and the floor would over-shoot, which is rare. In practice the floor binds.
+- Bootstrap = resampling with replacement from actual historical 30-day view counts. No distribution assumptions.
+- Sample window mirrors the same range over which the channel's projected views are computed, so the bootstrap reflects the same era of the channel that defined projected views. Staircase: 30–90 → 30–120 → 30–180 → 30–240. Always keep the bootstrap window inside the projected-views window — sampling beyond it mixes current projected views against a stale empirical distribution and produces misleading "channel under-delivers" results on recently-spiking channels.
+- Per-video "30-day view count" = the average of all view-count snapshots recorded for that video between ages 28 and 32 days inclusive, cast to integer. Averaging across the 5-day window smooths single-snapshot jitter; alternative aggregations (min ≈ age-28 snapshot, max ≈ age-32 snapshot) would lock to one end of the window.
+- Likelihood threshold for picking the bundle size = 80%.
+- Default max bundle size = 4; raise via `--max-bundle-size` up to a hard ceiling of 10. 5+ video buys imply long-term campaigns — pair the raised ceiling with `--target max` to actually pick a larger bundle.
+- Bundle-size sweep starts at 1 — single-video buys allowed when data supports it.
+- Upload cadence (`--rich-output`) is derived from the videos already fetched for the bootstrap — no extra query. If the fetched set spans more than 180 days, only the most recent 180 days are used; if it spans less (high-cadence channel), the actual span is used. Cadence = `(videos − 1) ÷ months` so the rate doesn't leak into the blank intervals before the earliest and after the most recent video. Campaign length = `bundle size ÷ cadence`.

--- a/skills/tl-views-guarantee/scripts/vg.py
+++ b/skills/tl-views-guarantee/scripts/vg.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Views Guarantee calculator.
+
+Usage:
+    vg.py <channel_id_or_name>                     # single-answer mode
+    vg.py <channel_id_or_name> --sweep             # recommendation + full table
+    vg.py <channel_id_or_name> --rich-output       # adds per-video VG, cadence, campaign length
+    vg.py <channel_id_or_name> --max-bundle-size 8 # raise the bundle ceiling (default 4, up to 10)
+    vg.py <channel_id_or_name> --target max        # pick the largest bundle that clears 80%
+"""
+
+# ruff: noqa: T201
+# This is a standalone CLI script; print is the intended output mechanism.
+
+import argparse
+import datetime
+import json
+import random
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import TypedDict
+
+SEED = 42  # passed to a fresh random.Random in bootstrap_sweep so each call starts from the same RNG state
+DEFAULT_MAX_BUNDLE_SIZE = 4
+HARD_MAX_BUNDLE_SIZE = 10
+N_SIMS = 10000
+TARGET_LIKELIHOOD = 0.80
+FLOOR_PCT = 0.75
+MIN_SAMPLE = 5
+THIN_SAMPLE = 10
+MIN_VIDEO_AGE_DAYS = 30
+# Upper cap on the cadence window (days). The actual span used is the smaller of this and
+# the age of the oldest video in the already-fetched bootstrap sample — no extra ES query.
+CADENCE_WINDOW_DAYS = 180
+# Window staircase (upper bound, in days). Mirrors the PV calculator's range so the bootstrap
+# samples from the same era of the channel that defined PV. Widen only when the narrower window
+# has fewer than MIN_SAMPLE videos; never sample beyond the last step.
+SAMPLE_WINDOW_STEPS: list[int] = [90, 120, 180, 240]
+PRIMARY_WINDOW_MAX_DAYS: int = SAMPLE_WINDOW_STEPS[0]
+# Relative VG difference between primary and full-range results that, by itself, qualifies as
+# an inconsistency. Differences in chosen N or in the 80%-likelihood-reached flag also qualify.
+INCONSISTENCY_VG_DIFF = 0.10
+
+
+class _ChannelShowResult(TypedDict, total=False):
+    name: str
+    projected_views: int | None
+
+
+class _V30Row(TypedDict):
+    id: str
+    v30: int | None
+
+
+@dataclass(frozen=True)
+class ChannelInfo:
+    id: str
+    name: str
+    projected_views: int | None
+
+
+@dataclass(frozen=True)
+class BootstrapRow:
+    N: int
+    vg: int
+    likelihood: float
+    floor: int
+    p20: int
+
+
+def run(cmd: list[str], on_error: str | None = None) -> str:
+    r = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if r.returncode != 0:
+        sys.stderr.write(r.stderr)
+        sys.exit(on_error or f"command failed: {' '.join(cmd)} (exit {r.returncode})")
+    return r.stdout
+
+
+def resolve_channel(arg: str) -> ChannelInfo:
+    if arg.isdigit():
+        out = run(["tl", "channels", "show", arg, "--json"])
+        results: list[_ChannelShowResult] = json.loads(out)["results"]
+        if not results:
+            sys.exit(f"no channel found with id '{arg}'")
+        result = results[0]
+        return ChannelInfo(id=arg, name=result["name"], projected_views=result.get("projected_views"))
+
+    out = run(
+        ["tl", "channels", "find", arg],
+        on_error=f"no channel found matching '{arg}' (or ambiguous — see stderr above)",
+    )
+    found: list[dict[str, object]] = json.loads(out)["results"]
+    if not found:
+        sys.exit(f"no channel found matching '{arg}'")
+    return resolve_channel(str(found[0]["id"]))
+
+
+def get_v30_sample(channel_id: str, force_full_range: bool = False) -> tuple[list[int], int, list[int]]:
+    """Return (sample, window_max_days, fetched_ages).
+
+    - `sample`: 30-day view counts for the videos inside the chosen staircase window.
+    - `window_max_days`: upper-bound age (days) of the window actually used.
+    - `fetched_ages`: ages (days) of every video pulled from ES before the staircase narrowed
+      anything. Reused by the cadence calculator to avoid a second ES query.
+
+    Walks the SAMPLE_WINDOW_STEPS staircase: takes everything in 30..steps[i]; widens to the next
+    step only when the current window has fewer than MIN_SAMPLE videos. When force_full_range=True,
+    skips the staircase and samples directly from 30..SAMPLE_WINDOW_STEPS[-1]. Caller is
+    responsible for enforcing MIN_SAMPLE on the returned sample.
+    """
+    today = datetime.datetime.now(tz=datetime.UTC).date()
+    widest_max: int = SAMPLE_WINDOW_STEPS[-1]
+    # Bound publication_date precisely: at least MIN_VIDEO_AGE_DAYS old (so 30-day view data
+    # exists) and no older than the widest window step. ES returns the 40 most-recent longform
+    # videos in that range, freshest first.
+    oldest_ok = (today - datetime.timedelta(days=widest_max)).isoformat()
+    newest_ok = (today - datetime.timedelta(days=MIN_VIDEO_AGE_DAYS)).isoformat()
+    es_body = {
+        "size": 40,
+        "_source": ["id", "publication_date"],
+        "query": {
+            "bool": {
+                "filter": [
+                    {"term": {"channel.id": str(channel_id)}},
+                    {"term": {"content_type": "longform"}},
+                    {
+                        "range": {
+                            "publication_date": {
+                                "gte": oldest_ok,
+                                "lte": newest_ok,
+                                "format": "yyyy-MM-dd",
+                            }
+                        }
+                    },
+                ]
+            }
+        },
+        "sort": [{"publication_date": {"order": "desc"}}],
+    }
+    out = run(["tl", "db", "es", json.dumps(es_body), "--json"])
+    upload_rows: list[dict[str, str]] = json.loads(out)["results"]
+
+    # The ES range constrains age to [MIN_VIDEO_AGE_DAYS, widest_max]; the staircase below narrows
+    # it further. Bare YouTube ID (split off the compound `<channel>:<youtube>` form) is what the
+    # Firebolt query keys on. Sort freshest-first for deterministic ordering independent of ES.
+    aged_with_age: list[tuple[str, int]] = [
+        (row["id"].split(":", 1)[1], (today - datetime.date.fromisoformat(row["publication_date"])).days) for row in upload_rows
+    ]
+    aged_with_age.sort(key=lambda pair: pair[1])
+    fetched_ages: list[int] = [age for _, age in aged_with_age]
+
+    if not aged_with_age:
+        return [], PRIMARY_WINDOW_MAX_DAYS, fetched_ages
+
+    chosen_max: int = widest_max
+    chosen_ids: list[str] = []
+    if force_full_range:
+        chosen_ids = [uid for uid, age in aged_with_age if age <= widest_max]
+        chosen_max = widest_max
+    else:
+        for window_max in SAMPLE_WINDOW_STEPS:
+            ids_in_window = [uid for uid, age in aged_with_age if age <= window_max]
+            if len(ids_in_window) >= MIN_SAMPLE:
+                chosen_max = window_max
+                chosen_ids = ids_in_window
+                break
+        else:
+            chosen_ids = [uid for uid, age in aged_with_age if age <= chosen_max]
+
+    if not chosen_ids:
+        return [], chosen_max, fetched_ages
+    quoted = ",".join(f"'{v}'" for v in chosen_ids)
+    q = (
+        f"SELECT id, CAST(AVG(view_count) FILTER (WHERE age >= 28 AND age <= 32) AS BIGINT) AS v30 "
+        f"FROM article_metrics WHERE channel_id = {channel_id} "
+        f"AND id IN ({quoted}) GROUP BY id"
+    )
+    out = run(["tl", "db", "fb", q, "--json"])
+    v30_rows: list[_V30Row] = json.loads(out)["results"]
+    # Build sample in the deterministic publication-date order from `chosen_ids`. The Firebolt query
+    # has no ORDER BY, so v30_rows can come back in different orders across runs — picking by index
+    # into a shuffled list would make the seeded RNG hit different elements each invocation.
+    v30_by_id: dict[str, int | None] = {r["id"]: r["v30"] for r in v30_rows}
+    sample: list[int] = [v for uid in chosen_ids if (v := v30_by_id.get(uid)) is not None]
+    return sample, chosen_max, fetched_ages
+
+
+def bootstrap_sweep(sample: list[int], projected_views: int, max_bundle_size: int) -> list[BootstrapRow]:
+    rng = random.Random(SEED)
+    rows: list[BootstrapRow] = []
+    for N in range(1, max_bundle_size + 1):
+        totals: list[int] = [sum(rng.choices(sample, k=N)) for _ in range(N_SIMS)]
+        totals.sort()
+        p20: int = totals[int(N_SIMS * 0.20)]
+        floor: int = int(FLOOR_PCT * N * projected_views)
+        vg: int = max(floor, p20)
+        likelihood: float = sum(1 for t in totals if t >= vg) / N_SIMS
+        rows.append(BootstrapRow(N=N, vg=vg, likelihood=likelihood, floor=floor, p20=p20))
+    return rows
+
+
+def pick_bundle(rows: list[BootstrapRow], target: str) -> tuple[BootstrapRow, bool]:
+    """Pick the recommended bundle.
+
+    With qualifying rows (likelihood ≥ TARGET_LIKELIHOOD): smallest N (target=min) or largest N
+    (target=max). With nothing qualifying: pick the row whose meaning best matches the target —
+    max likelihood (with smaller N as tiebreaker) for target=min, max N for target=max.
+    """
+    qualifying = [r for r in rows if r.likelihood >= TARGET_LIKELIHOOD]
+    if qualifying:
+        return (qualifying[0] if target == "min" else qualifying[-1]), False
+    if target == "min":
+        return max(rows, key=lambda r: (r.likelihood, -r.N)), True
+    return rows[-1], True
+
+
+def cadence_per_month(fetched_ages: list[int]) -> float | None:
+    """Longform upload cadence (videos / month) derived from already-fetched ages.
+
+    Uses videos up to CADENCE_WINDOW_DAYS old; if the fetched set spans further the older tail
+    is dropped. The N−1 in the formula accounts for the fact that N timestamps describe N−1
+    intervals over span_days — without it the rate would over-count by attributing fractional
+    videos to the blank gaps before the earliest and after the most recent video in the window.
+    """
+    in_window = [a for a in fetched_ages if a <= CADENCE_WINDOW_DAYS]
+    if len(in_window) < 2:
+        return None
+    span_days = max(in_window) - min(in_window)
+    if span_days <= 0:
+        return None
+    return (len(in_window) - 1) / (span_days / 30)
+
+
+def fmt_campaign_length(N: int, cadence: float | None) -> str:
+    if not cadence:
+        return "n/a"
+    return f"~{N / cadence:.1f} months"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("channel")
+    ap.add_argument("--sweep", action="store_true")
+    ap.add_argument(
+        "--full-range",
+        action="store_true",
+        help="Force the sample to come from the full 30-240d window, skipping the staircase.",
+    )
+    ap.add_argument(
+        "--max-bundle-size",
+        type=int,
+        default=DEFAULT_MAX_BUNDLE_SIZE,
+        help=(f"Largest bundle size to consider (default {DEFAULT_MAX_BUNDLE_SIZE}, up to {HARD_MAX_BUNDLE_SIZE})."),
+    )
+    ap.add_argument(
+        "--target",
+        choices=["min", "max"],
+        default="min",
+        help=(
+            "Optimization target: smallest bundle that clears 80%% (min, default) or largest that "
+            "clears 80%% (max). With --target max and adequate data the answer almost always "
+            "equals --max-bundle-size."
+        ),
+    )
+    ap.add_argument(
+        "--rich-output",
+        action="store_true",
+        help="Include per-video VG, upload cadence, and campaign length in both modes.",
+    )
+    args = ap.parse_args()
+    channel_arg: str = args.channel
+    use_sweep: bool = args.sweep
+    use_full_range: bool = args.full_range
+    max_bundle_size: int = args.max_bundle_size
+    target: str = args.target
+    rich_output: bool = args.rich_output
+
+    if not 1 <= max_bundle_size <= HARD_MAX_BUNDLE_SIZE:
+        sys.exit(f"--max-bundle-size must be between 1 and {HARD_MAX_BUNDLE_SIZE} (got {max_bundle_size})")
+
+    channel = resolve_channel(channel_arg)
+    if channel.projected_views is None:
+        sys.exit(
+            f"channel {channel.name} ({channel.id}) has no projected_views — usually means "
+            f"the channel hasn't published enough content to establish a baseline. Statistical "
+            f"VG not available; fall back on your own judgement."
+        )
+    pv: int = channel.projected_views
+
+    sample, window_max, fetched_ages = get_v30_sample(channel.id, force_full_range=use_full_range)
+    if len(sample) < MIN_SAMPLE:
+        sys.exit(f"insufficient data — only {len(sample)} videos with 30-day view data (need {MIN_SAMPLE}+)")
+
+    rows = bootstrap_sweep(sample, pv, max_bundle_size)
+    chosen, fallback = pick_bundle(rows, target)
+
+    widest_max: int = SAMPLE_WINDOW_STEPS[-1]
+    inconsistency_banner: str = ""
+    # Only worth comparing against the full range when the primary sample is thin AND the
+    # staircase actually narrowed (otherwise the full-range answer is the primary answer).
+    if not use_full_range and window_max != widest_max and len(sample) < THIN_SAMPLE:
+        full_sample, _, _ = get_v30_sample(channel.id, force_full_range=True)
+        if len(full_sample) >= MIN_SAMPLE:
+            full_rows = bootstrap_sweep(full_sample, pv, max_bundle_size)
+            full_chosen, full_fallback = pick_bundle(full_rows, target)
+            vg_diff: float = abs(chosen.vg - full_chosen.vg) / chosen.vg
+            if chosen.N != full_chosen.N or fallback != full_fallback or vg_diff >= INCONSISTENCY_VG_DIFF:
+                inconsistency_banner = (
+                    f"⚠️  INCONSISTENT RESULTS: primary 30-{window_max}d sample disagrees with "
+                    f"the full 30-{widest_max}d sample. Re-run with --full-range to compare."
+                )
+
+    thin_sample_banner: str = (
+        f"⚠️  THIN SAMPLE: only {len(sample)} videos — bootstrap variance is high, treat result as approximate." if len(sample) < THIN_SAMPLE else ""
+    )
+    window_banner: str = (
+        f"⚠️  FALLBACK WINDOW: primary 30-{PRIMARY_WINDOW_MAX_DAYS}d window had fewer than "
+        f"{MIN_SAMPLE} videos. Sample drawn from 30-{window_max}d. "
+        f"VG reflects older performance - treat as less current."
+        if window_max != PRIMARY_WINDOW_MAX_DAYS and not use_full_range
+        else ""
+    )
+
+    cadence: float | None = cadence_per_month(fetched_ages) if rich_output else None
+    fb_note: str = "  ⚠️  no bundle size hit 80% — reporting closest match" if fallback else ""
+
+    # Recommendation block (both modes; capitalized labels)
+    print(f"Channel: {channel.name} ({channel.id})")
+    print(f"Video bundle size: {chosen.N}")
+    print(f"Views guarantee: {chosen.vg:,.0f}")
+    print(f"Likelihood to hit: {chosen.likelihood:.0%}{fb_note}")
+
+    # Sweep+rich context lines slot between the headline numbers and the per-bundle rich lines.
+    if use_sweep and rich_output:
+        print(f"Projected views: {pv:,}")
+        print(f"Sample size: {len(sample)} videos")
+        print(f"Sample window: 30-{window_max}d")
+
+    # Per-bundle rich lines (both modes when --rich-output is set).
+    if rich_output:
+        print(f"Per-video VG: {chosen.vg // chosen.N:,}")
+        cad_str = f"{cadence:.1f}/month" if cadence else "n/a"
+        print(f"Upload cadence: {cad_str}")
+        print(f"Campaign length: {fmt_campaign_length(chosen.N, cadence)}")
+
+    if use_sweep:
+        print()
+        if rich_output:
+            print(f"{'Bundle size':>11}  {'Campaign length':>15}  {'VG':>12}  {'VG/video':>10}  {'Likelihood':>10}")
+            for r in rows:
+                marker = "  ←" if r.N == chosen.N else ""
+                cl = fmt_campaign_length(r.N, cadence)
+                print(f"{r.N:>11}  {cl:>15}  {r.vg:>12,.0f}  {r.vg // r.N:>10,}  {r.likelihood:>9.0%}{marker}")
+        else:
+            print(f"{'Bundle size':>11}  {'VG':>12}  {'Likelihood':>10}")
+            for r in rows:
+                marker = "  ←" if r.N == chosen.N else ""
+                print(f"{r.N:>11}  {r.vg:>12,.0f}  {r.likelihood:>9.0%}{marker}")
+        print()
+
+    if thin_sample_banner:
+        print(thin_sample_banner)
+    if window_banner:
+        print(window_banner)
+    if inconsistency_banner:
+        print(inconsistency_banner)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Bundles the **views-guarantee** calculator (previously a local-only skill) into the CLI's distributed skill set under the official name `tl-views-guarantee`.

Given a channel ID or name, the skill bootstrap-simulates the channel's recent longform video performance (view counts at age ~30 days) and returns:

```
Channel: Sydney Watson (20107)
Video bundle size: 2
views guarantee: 526,470
likelihood to hit: 80%
```

`--sweep` prints the full table across bundle sizes 1–4; `--full-range` forces the widest sample window.

## How it fits

- New directory `skills/tl-views-guarantee/` (`SKILL.md` + `scripts/vg.py`). Skills are auto-discovered by directory iteration in `setup.py` and force-included into the wheel via `pyproject.toml`, so no registry/manifest changes are needed.
- Script path in `SKILL.md` uses the `<SKILL_DIR>` placeholder convention (matching `tl-keyword-research`) so it resolves regardless of install location (`~/.claude`, `~/.agents`, opencode, plugin namespace).

## Data access

Video sampling goes through `tl db es`: the 40 most-recent **longform** uploads within a precise `publication_date` range — at least 30 days old (so 30-day view data exists) and no older than the projected-views window — ordered most-recent-first. Per-video 30-day view counts come from `tl db fb`.

## Notes

- No version bump in this PR, matching the precedent of the channel-authenticity skill addition (#58); releases are cut as separate `vX.Y.Z` commits.
- No skill-enumeration tests exist to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)