### PR TITLE
Echo a report's contents when it's created

### DIFF
--- a/src/tl_cli/commands/reports.py
+++ b/src/tl_cli/commands/reports.py
@@ -22,6 +22,71 @@ REPORT_TYPE_LABELS = {1: "Content", 2: "Brands", 3: "Channels", 8: "Sponsorships
 
 POLL_INTERVAL = 2  # seconds between server polls
 
+# Filterset keys that pin specific entities into a report (the curated-ID
+# lists). A report built from these holds exactly those records; a report built
+# from predicate filters re-evaluates against live data and pins nothing.
+_PIN_ENTITIES = ("channels", "brands", "sponsorships", "articles")
+# Filterset keys that are structural, not user-facing predicate filters.
+_NON_PREDICATE_KEYS = {"keyword_operator", "sort"}
+
+
+def _summarize_report_contents(config: dict) -> dict:
+    """Summarize what a saved report config actually contains.
+
+    Returns the report-type label, a per-entity count of *pinned* IDs (the
+    curated lists that freeze specific channels/brands/sponsorships/articles
+    into the report), and the active predicate-filter keys. Lets a caller —
+    human or agent — catch a filters-vs-pinned-IDs mismatch (or a wholly blank
+    report) before sharing the link: a report built from a natural-language
+    prompt yields predicate filters and pins *nothing*, so "pinned: none" is
+    the tell that it doesn't contain the specific records the user named.
+    """
+    filterset = config.get("filterset") or {}
+    pinned = {
+        entity: len(filterset[entity])
+        for entity in _PIN_ENTITIES
+        if isinstance(filterset.get(entity), list) and filterset[entity]
+    }
+    skip = set(_PIN_ENTITIES) | {f"exclude_{e}" for e in _PIN_ENTITIES} | _NON_PREDICATE_KEYS
+    filters = sorted(
+        key
+        for key, value in filterset.items()
+        if key not in skip and value not in (None, "", [], {}, False)
+    )
+    return {
+        "report_type": REPORT_TYPE_LABELS.get(config.get("report_type"), config.get("report_type")),
+        "pinned": pinned,
+        "filters": filters,
+    }
+
+
+def _render_contents_line(summary: dict) -> str:
+    """One-line human rendering of a `_summarize_report_contents` result."""
+    pinned = summary.get("pinned") or {}
+    pin_str = ", ".join(f"{count} {entity}" for entity, count in pinned.items()) if pinned else "none"
+    filters = summary.get("filters") or []
+    filt_str = ", ".join(filters) if filters else "none"
+    return f"Contents: {summary.get('report_type')} report · pinned: {pin_str} · filters: {filt_str}"
+
+
+def _print_contents_summary(summary: dict) -> None:
+    """Surface a saved report's contents on stderr (safe in every output mode).
+
+    A report with no pinned entities *and* no filters gets a loud warning —
+    that blank/default state is the failure behind "you sent me an empty
+    report". Otherwise a dim one-liner lets the caller confirm the report holds
+    what the user actually asked for.
+    """
+    line = _render_contents_line(summary)
+    if not summary.get("pinned") and not summary.get("filters"):
+        err.print(
+            f"[yellow]⚠ {line}\n"
+            f"  This report has no filters and no pinned entities — it will show "
+            f"a blank/default view.[/yellow]"
+        )
+    else:
+        err.print(f"[dim]{line}[/dim]")
+
 
 @app.callback(invoke_without_command=True)
 def reports(
@@ -404,6 +469,13 @@ def create_report(
         report_url = result.get("report_url", "")
         campaign_id = result.get("campaign_id", "")
 
+        # Echo what the report actually contains. Surfaced even under
+        # --yes/--json (the agent path), so a report built from a prompt —
+        # which yields predicate filters and pins no specific IDs — can be
+        # spotted before its link is shared.
+        summary = _summarize_report_contents(config)
+        data["report_contents"] = summary
+
         if toon_output:
             print(toon_encode(data))
         elif json_output:
@@ -421,6 +493,8 @@ def create_report(
             usage = data.get("usage")
             if usage:
                 err.print(f"\n  [dim]{usage.get('credits_charged', 0)} credits · {usage.get('balance_remaining', '?')} remaining[/dim]")
+
+        _print_contents_summary(summary)
 
     except ApiError as e:
         handle_api_error(e)
@@ -541,23 +615,26 @@ def save_list_cmd(
     finally:
         client.close()
 
+    summary = _summarize_report_contents(config)
+    data["report_contents"] = summary
+
     if fmt == "toon":
         print(toon_encode(data))
-        return
-    if fmt == "json":
+    elif fmt == "json":
         print(json.dumps(data, indent=2, default=str))
-        return
+    else:
+        results = data.get("results", [{}])
+        result = results[0] if results else {}
+        err.print()
+        err.print("[green bold]Report created![/green bold]")
+        err.print(f"  Campaign ID: {result.get('campaign_id', '?')}")
+        err.print(f"  URL: https://app.thoughtleaders.io{result.get('report_url', '')}")
+        err.print(
+            "\n[dim]Refine columns, widgets, title, or description with "
+            "`tl reports update <id>`.[/dim]"
+        )
 
-    results = data.get("results", [{}])
-    result = results[0] if results else {}
-    err.print()
-    err.print("[green bold]Report created![/green bold]")
-    err.print(f"  Campaign ID: {result.get('campaign_id', '?')}")
-    err.print(f"  URL: https://app.thoughtleaders.io{result.get('report_url', '')}")
-    err.print(
-        "\n[dim]Refine columns, widgets, title, or description with "
-        "`tl reports update <id>`.[/dim]"
-    )
+    _print_contents_summary(summary)
 
 
 @app.command("update")

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -7,9 +7,66 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from tl_cli.commands.reports import _parse_config_arg, app
+from tl_cli.commands.reports import (
+    _parse_config_arg,
+    _render_contents_line,
+    _summarize_report_contents,
+    app,
+)
 
 runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# _summarize_report_contents / _render_contents_line
+# ---------------------------------------------------------------------------
+
+
+class TestReportContentsSummary:
+    def test_filter_only_report_pins_nothing(self) -> None:
+        # The exact shape that caused the real bug: a sponsorships report the
+        # AI builder produced from a prompt — a generic format predicate, no
+        # pinned deals.
+        summary = _summarize_report_contents(
+            {"report_type": 8, "filterset": {"channel_formats": [4]}}
+        )
+        assert summary["report_type"] == "Sponsorships"
+        assert summary["pinned"] == {}
+        assert summary["filters"] == ["channel_formats"]
+
+    def test_pinned_ids_counted_per_entity(self) -> None:
+        summary = _summarize_report_contents(
+            {"report_type": 8, "filterset": {"sponsorships": [1, 2, 3, 4, 5]}}
+        )
+        assert summary["pinned"] == {"sponsorships": 5}
+        assert summary["filters"] == []
+
+    def test_blank_report_has_no_pins_and_no_filters(self) -> None:
+        summary = _summarize_report_contents({"report_type": 3, "filterset": {}})
+        assert summary["pinned"] == {}
+        assert summary["filters"] == []
+        line = _render_contents_line(summary)
+        assert "pinned: none" in line and "filters: none" in line
+
+    def test_structural_keys_are_not_counted_as_filters(self) -> None:
+        # keyword_operator / sort are structural, not user-facing predicates.
+        summary = _summarize_report_contents(
+            {"report_type": 3, "filterset": {"keyword_operator": "and", "sort": "x", "channels": [9]}}
+        )
+        assert summary["pinned"] == {"channels": 1}
+        assert summary["filters"] == []
+
+    def test_empty_and_falsey_filter_values_ignored(self) -> None:
+        summary = _summarize_report_contents(
+            {"report_type": 3, "filterset": {"languages": [], "is_offline": False, "reach_from": 1000}}
+        )
+        assert summary["filters"] == ["reach_from"]
+
+    def test_render_line_mentions_pins_and_filters(self) -> None:
+        line = _render_contents_line(
+            {"report_type": "Sponsorships", "pinned": {"sponsorships": 5}, "filters": ["channel_formats"]}
+        )
+        assert "5 sponsorships" in line and "channel_formats" in line
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`tl reports create` returns only a URL — nothing about what the report actually *contains*. And with `--yes` (the path agents use) the config preview is skipped entirely.

So when an agent builds a report from a **natural-language prompt**, the AI Report Builder produces **predicate filters** and pins **no** specific IDs — but the agent just gets a link back, with no signal that the report doesn't hold the records the user named. In a real session, "make me a report of these 5 sponsorships" became a link to a generic `channel_formats=[4]` report with none of the 5 deals on it.

## Fix

Echo a contents summary on every report creation (`create` and `save-list`), surfaced in **all** output modes:

- a machine-readable `report_contents` block folded into the `--json`/`--toon` payload — report type, **per-entity pinned-ID counts**, and active filter keys;
- a one-line stderr summary (safe even under `--json`):

```
Contents: Sponsorships report · pinned: none · filters: channel_formats
```

`pinned: none` is the tell that a report holds no specific records — visible **before** the link is shared. A report built the right way reads `pinned: 5 sponsorships · filters: none`.

A report with **no pins and no filters** gets a loud warning — the blank/default state behind "you sent me an empty report":

```
⚠ Contents: Channels report · pinned: none · filters: none
  This report has no filters and no pinned entities — it will show a blank/default view.
```

## Tests
6 new cases in `tests/test_reports.py` cover `_summarize_report_contents` (filter-only vs pinned vs blank, structural-key exclusion, falsey-value handling) and `_render_contents_line`. Full suite green (122 passed).

## Notes
Pure additive output — no behavior change to what gets saved. Pairs naturally with a separate change that steers explicit-ID requests toward `save-list`/`bulk-import`, but stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)