### PR TITLE
Update sponsorship status vocabulary for approval-statuses backend change

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ ThoughtLeaders has its internal terminology that's exposed throughout this tool.
 * **Sponsorships** — Either possible or realised business relationships between brands and channels, stored in `thoughtleaders_adlink`. There are several specific sub-types differentiated by the row's `publish_status`:
     * *Deals* — Contractually agreed-upon sponsorships (sold; `publish_status = 3`). They can be in a production pipeline or already published.
     * *Matches* — Possible brand-channel pairings (`publish_status = 7`); ThoughtLeaders thinks they could work.
-    * *Proposals* — Matches that have been proposed to both sides (`publish_status = 0`).
+    * *Proposals* — Open sponsorships actively in negotiation between the two sides (`publish_status = 10`).
 * **Adspots** — types of ads a channel carries (e.g. mention, dedicated video, product placement). Returned by `tl channels show`; each carries price/cost and a computed CPM.
 * **AdLink** — engineering / DB name for the row that backs a sponsorship. Treat as interchangeable with "sponsorship"; the table is `thoughtleaders_adlink`.
 * **MSN** (Media Selling Network) — the ~12k YouTube channels that have opted in to receive sponsorship offers. A channel is in MSN if `channel.media_selling_network_join_date IS NOT NULL`.

--- a/agents/tl-analyst.md
+++ b/agents/tl-analyst.md
@@ -59,7 +59,7 @@ tl db pg "SELECT a.id, a.send_date, a.publish_status, b.name AS brand, ch.channe
           JOIN thoughtleaders_profile p ON a.creator_profile_id = p.id
           JOIN thoughtleaders_profile_brands pb ON p.id = pb.profile_id
           JOIN thoughtleaders_brand b ON pb.brand_id = b.id
-          WHERE a.publish_status = 2
+          WHERE a.publish_status = 10
             AND a.send_date < CURRENT_DATE
           ORDER BY a.send_date
           LIMIT 100 OFFSET 0"
@@ -103,7 +103,7 @@ tl db es '{"size": 0, "track_total_hits": true,
 
 ## Rules
 
-- **Always resolve numeric codes to human-readable labels** in your output. Never show "Status 3" — show "Sold". Status mapping: 0=Proposed, 1=Unavailable, 2=Pending, 3=Sold, 4=Rejected by Advertiser, 5=Rejected by Publisher, 6=Proposal Approved, 7=Matched, 8=Reached Out, 9=Rejected by Agency.
+- **Always resolve numeric codes to human-readable labels** in your output. Never show "Status 3" — show "Sold". Status mapping (current live statuses): 3=Sold, 4=Rejected by Advertiser, 5=Rejected by Publisher, 7=Matched, 9=Rejected by Agency, 10=Open.
 - Always use `--json` for output you need to parse
 - For raw `tl db pg`, prefer one well-targeted query over multiple structured walks; remember the LIMIT/OFFSET injected defaults (LIMIT 50, OFFSET 0) and the OFFSET ≥ 10000 → 403 ceiling.
 - Always include `--limit` on structured list queries to control credit spend

--- a/skills/tl-save-report/SKILL.md
+++ b/skills/tl-save-report/SKILL.md
@@ -254,10 +254,10 @@ Date upper bounds: `start_date` / `end_date` are date-typed and use `< next_day`
 
 ### `publish_status` (type 8 only) — numeric IDs, not strings
 
-Sponsorship `publish_status` values are numeric IDs (0–9), **never string labels**. Don't emit `["sold"]` or `["live"]`. The canonical user-phrase → ID mapping is in [`references/report_glossary.md`](references/report_glossary.md) under "Deal-stage jargon". Quick anchors:
+Sponsorship `publish_status` values are numeric IDs from the set `{3, 4, 5, 7, 9, 10}`, **never string labels**. Don't emit `["sold"]` or `["live"]`. The canonical user-phrase → ID mapping is in [`references/report_glossary.md`](references/report_glossary.md) under "Deal-stage jargon". Quick anchors:
 
 - `[3]` = sold
-- `[0, 2, 6, 7, 8]` = pipeline / pre-sale (proposed / pending / matched / outreach / proposal-approved)
+- `[7, 10]` = pipeline / pre-sale (matched / open)
 - `[3]` + `filters_json.ad_publish_status: "0"` = sold + currently live on the channel
 
 The `publish_status` field lives inside `filters_json`, not as a top-level FilterSet field.
@@ -408,7 +408,7 @@ For type 8 only, the `_over_<axis>` histograms (`count_sponsorships_over_send_da
 
 | `filters_json.publish_status` includes | Use axis | Aggregator names |
 | --- | --- | --- |
-| Pre-sale (0, 2, 6, 7, 8) | `send_date` (pipeline view) | `count_sponsorships_over_send_date`, `sum_price_over_send_date` |
+| Pre-sale (7, 10) — matched / open | `send_date` (pipeline view) | `count_sponsorships_over_send_date`, `sum_price_over_send_date` |
 | Sold only (3) | `purchase_date` (won-deals view) | `count_sponsorships_over_purchase_date`, `sum_price_over_purchase_date` |
 | Mix of pre-sale + sold | `send_date` (pipeline view dominates) | as pipeline |
 | Performance grades (winners/losers) | `purchase_date` | as won-deals |

--- a/skills/tl-save-report/references/report_glossary.md
+++ b/skills/tl-save-report/references/report_glossary.md
@@ -60,16 +60,35 @@ Map informal descriptions → `filters_json.publish_status` IDs (integer; platfo
 | User says | `publish_status` ID(s) | Other `filters_json` | Status name |
 |---|---|---|---|
 | "booked" / "sold" / "closed" / "won" | `3` | — | Sold |
-| "proposed" / "approved by creator" | `0` | — | Creator Approved |
-| "pending" | `2` | — | Pending |
+| "open" / "in negotiation" | `10` | — | Open |
 | "rejected" *(any side)* | `4, 5, 9` | — | Rejected by Brand / Creator / Agency |
 | "matched" | `7` | — | Matched |
-| "reached out" / "outreach" | `8` | — | Reached Out |
-| **"pipeline"** *(default)* | `0, 2, 6, 7, 8` | — | All active non-sold |
-| **"in progress"** / **"active"** | `0, 2, 3, 6` | — | Active incl. sold |
+| **"pipeline"** *(default)* | `7, 10` | — | Matched + Open (pre-sale) |
+| **"in progress"** / **"active"** | `3, 7, 10` | — | Active incl. sold |
 | **"live"** / **"currently running"** | `3` | `ad_publish_status: "0"` | Sold AND published |
 
-Full `publish_status` enum (all 12 codes incl. CLIENT_SIDE_* and pipeline weights) lives at the canonical schema home: [`tl/references/postgres-schema.md` → `publish_status` Constants](../../tl/references/postgres-schema.md#publish_status-constants). The NL → ID mapping above is what this skill consumes; refer to the schema doc for the full enum and Django-side constants.
+### Open and per-party approvals
+
+A deal at **Open** (`publish_status` `10`) is an active, in-negotiation deal. Its progress is tracked by three independent per-party approval fields, each `PENDING`, `APPROVED`, `FINISHED`, or unset (`null`):
+
+- `brand_approval` — the advertiser's sign-off
+- `channel_approval` — the creator's sign-off
+- `agency_approval` — the agency's sign-off (when an agency is involved)
+
+These are **first-class FilterSet properties** — set directly on the report, not as keys inside `filters_json`. Each takes a comma list of `PENDING`/`APPROVED`/`FINISHED` (or ints `1`/`2`/`3`), plus `0`/`null`/`none` to match unset. They narrow the Open rows only and have no effect unless `publish_status` includes `10`.
+
+The `committed` flag is a `filters_json` key (like `publish_status`): `filters_json.committed: "1"` selects Sold deals together with Open deals the brand has approved.
+
+Users often name a deal by where it sits inside Open. Map those phrases to `publish_status` `10` plus the matching approval state:
+
+| User says | `publish_status` | Approval filter (first-class) | Meaning |
+|---|---|---|---|
+| "reached out" / "outreach" | `10` | `channel_approval = PENDING` | Creator contacted, awaiting their reply |
+| "proposed" / "creator approved" | `10` | `channel_approval = APPROVED` | Creator has agreed |
+| "proposal approved" | `10` | `brand_approval = PENDING` | Brand is reviewing |
+| "pending" | `10` | `brand_approval = APPROVED` | Brand has committed |
+
+The `publish_status` set is `{3, 4, 5, 7, 9, 10}` (3 Sold, 4 Rejected by Brand, 5 Rejected by Creator, 7 Matched, 9 Rejected by Agency, 10 Open). The canonical schema home is [`tl/references/postgres-schema.md` → `publish_status` Constants](../../tl/references/postgres-schema.md#publish_status-constants); refer to it for the full enum.
 
 ## Field-pair disambiguation
 

--- a/skills/tl-save-report/references/sortable_columns.json
+++ b/skills/tl-save-report/references/sortable_columns.json
@@ -52,7 +52,7 @@
     {"name": "Scheduled Date", "backend_code": "send_date", "sortability": "both", "description": ""},
     {"name": "Price", "backend_code": "price", "sortability": "both", "description": ""},
     {"name": "Cost", "backend_code": "cost", "sortability": "both", "description": ""},
-    {"name": "Weighted price", "backend_code": "weighted_price", "sortability": "both", "description": "Price * (publish_status weight/100)."},
+    {"name": "Weighted price", "backend_code": "weighted_price", "sortability": "both", "description": "Price weighted by the brand/channel approval combination on open deals."},
     {"name": "Projected Views", "backend_code": "ad_spot__channel__impression", "sortability": "both", "description": ""},
     {"name": "Status", "backend_code": "publish_status", "sortability": "both", "description": "Status of the deal."},
     {"name": "Created", "backend_code": "created_at", "sortability": "both", "description": "Creation date of the sponsorship."},

--- a/skills/tl-save-report/references/sponsorship_filterset_schema.json
+++ b/skills/tl-save-report/references/sponsorship_filterset_schema.json
@@ -149,6 +149,19 @@
       "description": "Restrict to sponsorships TL sourced/managed (vs. organic/external sponsorship signals)."
     },
 
+    "brand_approval": {
+      "type": ["string", "null"],
+      "description": "Narrows OPEN (publish_status 10) rows by the advertiser's per-party approval state. Comma list of PENDING/APPROVED/FINISHED or ints 1/2/3, plus 0/null/none for unset. Has no effect unless publish_status includes 10."
+    },
+    "channel_approval": {
+      "type": ["string", "null"],
+      "description": "Narrows OPEN (publish_status 10) rows by the creator's per-party approval state. Same value forms as brand_approval. Has no effect unless publish_status includes 10."
+    },
+    "agency_approval": {
+      "type": ["string", "null"],
+      "description": "Narrows OPEN (publish_status 10) rows by the agency's per-party approval state. Same value forms as brand_approval. Has no effect unless publish_status includes 10."
+    },
+
     "msn_start_date": { "type": ["string", "null"], "format": "date" },
     "msn_end_date":   { "type": ["string", "null"], "format": "date" },
     "msn_channels_only": {
@@ -166,9 +179,10 @@
       "type": ["object", "null"],
       "description": "Catch-all JSONField the platform interprets directly. For type 8 this is the primary place to encode publish_status, deal_status, price ranges, and any sponsorship-specific signals that don't have a first-class column on FilterSet.",
       "_tl_intent_hints": [
-        "publish_status: encode the user's intent ('live', 'pending', 'sold', 'proposed') here; the platform reads it.",
+        "publish_status: encode the user's intent ('matched', 'open', 'sold', 'live') here; the platform reads it.",
         "ad_publish_status: live/currently-running intent uses string value '0' together with publish_status [3] — the platform interprets that combination as 'sold deals that are currently live' (filters to base-table publish_date IS NOT NULL).",
-        "Deal-stage filtering (matches → proposals → deals) goes through filters_json — there is no first-class status field on FilterSet."
+        "Deal-stage filtering (matches → proposals → deals) goes through filters_json — there is no first-class status field on FilterSet.",
+        "committed: set committed '1' here to select committed deals (SOLD ∪ brand-approved OPEN); use it rather than AND-ing publish_status with brand_approval, which drops sold rows whose approval fields are unset."
       ]
     }
   },
@@ -181,7 +195,7 @@
   "_tl_rules": [
     "Type 8 ALWAYS needs a date scope. If the user gave no date hint at all, surface a follow-up question rather than silently defaulting — an unscoped type-8 report returns the entire AdLink table and is almost never what the user wanted. For vague-but-nonzero date language ('recent', 'lately', 'this year'), the `default_date_scope` intent override below applies the 365-day default with judgment.",
     "Do NOT invent fields. Sponsorship status / publish_status / deal stage all live inside `filters_json` — encode them there, not as new top-level keys.",
-    "publish_status values are NUMERIC IDs (0–9), not string labels. See `report_glossary.md`'s 'Deal-stage jargon' table for the canonical user-phrase → ID mapping. The intent overrides below already use numeric IDs; never emit `publish_status: ['live']` or `['sold']` — those strings are not in the platform's enum.",
+    "publish_status values are NUMERIC IDs from the set {3, 4, 5, 7, 9, 10}, not string labels. See `report_glossary.md`'s 'Deal-stage jargon' table for the canonical user-phrase → ID mapping. The intent overrides below already use numeric IDs; never emit `publish_status: ['live']` or `['sold']` — those strings are not in the platform's enum.",
     "Resolve brand/channel names → IDs via `tl brands find <name>` / `tl channels find <name>` BEFORE emitting `brands` / `channels` arrays. Type 8 with unresolved names is a hard failure mode — the saved report returns zero rows.",
     "Keyword fields (`keywords`, `keyword_operator`, `content_fields`, `keyword_content_fields_map`, `keyword_exclude_map`) exist on the model but are inert for type 8 — sponsorships are filtered by relations, not content text. Do not emit them.",
     "Topic fields (`topics`) are inert for type 8 — same reason. Do not emit.",
@@ -201,8 +215,8 @@
     },
     "active_pipeline_intent": {
       "trigger_phrases": ["pipeline", "active sponsorships", "in progress"],
-      "_describes": "All non-rejected, non-sold deals in motion (proposed → reached out → matched → pending → proposal approved).",
-      "set_in_filters_json": { "publish_status": [0, 2, 6, 7, 8] }
+      "_describes": "Matched + open deals in motion (non-rejected, non-sold).",
+      "set_in_filters_json": { "publish_status": [7, 10] }
     },
     "tl_book_intent": {
       "trigger_phrases": ["our deals", "tl book of business", "deals we managed"],

--- a/skills/tl-save-report/references/sponsorship_widget_schema.json
+++ b/skills/tl-save-report/references/sponsorship_widget_schema.json
@@ -111,7 +111,7 @@
   "_tl_axis_branching": {
     "description": "Both histograms in a single type-8 report MUST use the SAME axis. Pick by filters_json.publish_status content.",
     "rules": [
-      { "publish_status_includes": [0, 2, 6, 7, 8], "axis": "send_date",     "use_aggregators": ["count_sponsorships_over_send_date", "sum_price_over_send_date"], "label": "pipeline view" },
+      { "publish_status_includes": [7, 10], "axis": "send_date",     "use_aggregators": ["count_sponsorships_over_send_date", "sum_price_over_send_date"], "label": "pipeline view" },
       { "publish_status_only":     [3],             "axis": "purchase_date", "use_aggregators": ["count_sponsorships_over_purchase_date", "sum_price_over_purchase_date"], "label": "won-deals view" },
       { "publish_status_includes_pre_sale_and_sold": true, "axis": "send_date", "label": "mixed pipeline (send_date dominates)" },
       { "performance_grades_present": true, "axis": "purchase_date", "label": "performance view" }

--- a/skills/tl-save-report/references/widgets.md
+++ b/skills/tl-save-report/references/widgets.md
@@ -164,7 +164,7 @@ Two date axes — `send_date` (scheduled) and `purchase_date` (won). Histograms 
 
 | `filters_json.publish_status` includes | Use axis |
 |---|---|
-| Pre-sale (0, 2, 6, 7, 8) | `send_date` (pipeline view) |
+| Pre-sale (7, 10) — matched / open | `send_date` (pipeline view) |
 | Sold (3) only | `purchase_date` (won-deals view) |
 | Mix of pre-sale + sold | `send_date` (pipeline view dominates) |
 | Performance grades (winners/losers) | `purchase_date` |

--- a/skills/tl-top-partnerships/SKILL.md
+++ b/skills/tl-top-partnerships/SKILL.md
@@ -26,7 +26,7 @@ For every sold sponsorship the brand has where the video has actually gone live 
 - **Delta** = `live_eCPM - sold_date_eCPM`
   - Negative delta = the deal got *cheaper* per view than promised (good for the brand). Positive delta = the deal underdelivered.
 
-It also pulls **future bookings** — any sponsorship with status sold / proposal_approved / pending and a send date strictly after today — and tags each deal and each channel with the earliest future send date, or "Re-book - no future spot" if none exists. This turns the report into an actionable list, not just a backward look.
+It also pulls **future bookings** — any sponsorship that is sold, or open with the brand having reviewed it (`brand_approval` pending or approved), with a send date strictly after today — and tags each deal and each channel with the earliest future send date, or "Re-book - no future spot" if none exists. This turns the report into an actionable list, not just a backward look.
 
 ## Output
 

--- a/skills/tl-top-partnerships/scripts/top_partnerships.py
+++ b/skills/tl-top-partnerships/scripts/top_partnerships.py
@@ -78,16 +78,26 @@ def tl_list(*args) -> list[dict]:
 
 def fetch_future_bookings(brand: str) -> dict[str, dict]:
     """Return channel -> {send_date, status} for the earliest future booking per channel.
-    Future = send_date strictly after today, status in {sold, proposal_approved, pending}.
+    Future = send_date strictly after today, status sold, or open with the brand
+    having reviewed it (brand_approval pending or approved).
     """
     today = date.today()
     cutoff = (today + timedelta(days=1)).isoformat()
     end = (today + timedelta(days=365 * 2)).isoformat()
     rows: list[dict] = []
-    for status in ("sold", "proposal_approved", "pending"):
+    # sold deals: a plain status filter.
+    # open deals only count when the brand has reviewed them — narrow the OPEN
+    # arm with brand_approval (pending or approved); a bare status:open would
+    # over-count cold/un-reviewed open deals.
+    queries = (
+        ("sold", []),
+        ("open", ["brand_approval:PENDING,APPROVED"]),
+    )
+    for status, extra in queries:
         rows.extend(tl_list(
             f"brand:{brand}",
             f"status:{status}",
+            *extra,
             f"send-date-start:{cutoff}",
             f"send-date-end:{end}",
         ))

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -72,9 +72,9 @@ ThoughtLeaders is a sponsorship marketplace connecting **Brands** (advertisers /
 The centre of the data model are **Sponsorships** — business relationships between brands and channels. Sponsorships statuses form a sales funnel, from broad to narrow:
 
 - **Sponsorships** — the broadest category, encompassing all stages, stored in the `thoughtleaders_adlink` table.
-  - **Matches** — possible brand-channel pairings that ThoughtLeaders thinks could work
-  - **Proposals** — matches that have been proposed to both sides to consider
-  - **Deals** — contractually agreed-upon sponsorships (sold), either in production or published
+  - **Matches** — possible brand-channel pairings that ThoughtLeaders thinks could work (`publish_status=7`)
+  - **Proposals** — open sponsorships actively in negotiation between the two sides (`publish_status=10`, `open`)
+  - **Deals** — contractually agreed-upon sponsorships (sold; `publish_status=3`), either in production or published
 
 Sponsorships are sometimes called "Ads" or "Ad campaigns". **"AdLink"** is another name for the same thing — it's the term the database uses (`thoughtleaders_adlink`) and shows up across internal code, schema docs, and AM Slack threads. Treat "sponsorship" and "adlink" as interchangeable; the user-facing word is "sponsorship," the engineering/DB word is "adlink."
 
@@ -181,20 +181,20 @@ Filter-to-SQL examples (deals/matches/proposals all live on `thoughtleaders_adli
 | All sponsorships matching filters | `tl db pg "SELECT … FROM thoughtleaders_adlink WHERE …"` |
 | Sold deals (`publish_status=3`) | `tl db pg "SELECT … FROM thoughtleaders_adlink WHERE publish_status = 3"` |
 | Matched (`publish_status=7`) | `tl db pg "SELECT … FROM thoughtleaders_adlink WHERE publish_status = 7"` |
-| Proposed (`publish_status=0`) | `tl db pg "SELECT … FROM thoughtleaders_adlink WHERE publish_status = 0"` |
+| Open / in negotiation (`publish_status=10`) | `tl db pg "SELECT … FROM thoughtleaders_adlink WHERE publish_status = 10"` |
 | Video uploads from ElasticSearch | `tl db es '{"size":N,"query":{"term":{"channel.id":<id>}}}'` |
 
 Single-record / mutation commands:
 
 ```bash
 tl sponsorships show <id>              # Sponsorship detail
-tl sponsorships create --channel <id> --brand <id>  # Create proposal
+tl sponsorships create --channel <id> --brand <id>  # Create sponsorship (matched)
 tl sponsorships update <id> '<json>'   # Update a sponsorship
 tl deals show <id>                     # Deal detail
 tl matches show <id>                   # Match detail
 tl matches create --channel <id> --brand <id>  # Create match
 tl proposals show <id>                 # Proposal detail
-tl proposals create --channel <id> --brand <id>  # Create proposal
+tl proposals create --channel <id> --brand <id>  # Create sponsorship (matched)
 tl uploads show <id>                   # Upload detail
 tl channels show <id-or-name>          # Channel detail (accepts numeric ID or name) — for channel search use raw SQL on thoughtleaders_channel
 tl channels find <query>               # Resolve a string to {id, name}; accepts name/slug, YouTube URL/handle/ID, video URL (queues a scrape if no match)
@@ -246,10 +246,10 @@ This is the end-to-end workflow for proposing a sponsorship, then moving it thro
 
 #### Creating a sponsorship
 
-`tl sponsorships create` always creates the adlink in **proposed** status. Use the `tl matches create` or `tl proposals create` shortcuts when you specifically want a `matched` adlink or want a clearer log of intent — they share the same backend and accept the same flags.
+`tl sponsorships create` creates the adlink in **matched** status by default. Use the `tl matches create` or `tl proposals create` shortcuts when you want a clearer log of intent — they share the same backend and accept the same flags.
 
 ```bash
-# Minimum: channel ID + brand ID. Creates a proposal (publish_status=PREVIEW=0).
+# Minimum: channel ID + brand ID. Creates a match (publish_status=MATCHED=7).
 tl sponsorships create --channel 5607 --brand 11459
 
 # Optional price (USD):
@@ -267,10 +267,10 @@ tl sponsorships create -c 5607 -b 11459 --json | jq -r '.results[0].sponsorship_
 
 # Shortcuts (delegated to the same server endpoint with a preset status):
 tl matches create -c 5607 -b 11459      # creates with publish_status=matched (7)
-tl proposals create -c 5607 -b 11459    # creates with publish_status=proposed (0)
+tl proposals create -c 5607 -b 11459    # creates with publish_status=matched (7)
 ```
 
-Required: `--channel/-c <int>`, `--brand/-b <int>` (or the equivalent keys in the JSON body). Optional: `--price/-p <float>`, `--json`, `--toon`. **JSON and command-line flags are mutually exclusive on `tl sponsorships create` — pass one form or the other, never both.** The JSON body accepts `channel_id`, `brand_id`, `price`, and optionally `status`; defaults to `status: "proposed"` if omitted. Returns the created adlink with a `tl sponsorships show <id>` hint.
+Required: `--channel/-c <int>`, `--brand/-b <int>` (or the equivalent keys in the JSON body). Optional: `--price/-p <float>`, `--json`, `--toon`. **JSON and command-line flags are mutually exclusive on `tl sponsorships create` — pass one form or the other, never both.** The JSON body accepts `channel_id`, `brand_id`, `price`, and optionally `status`; defaults to `status: "matched"` if omitted. Returns the created adlink with a `tl sponsorships show <id>` hint.
 
 The adlink is owned by the **brand's** advertiser profile (not the calling user's profile) and its `list` FK is set to the requested brand — so the new sponsorship appears under the brand's pipeline, not the AM's.
 
@@ -278,9 +278,13 @@ The adlink is owned by the **brand's** advertiser profile (not the calling user'
 
 After a sponsorship exists, `tl sponsorships update <id> '<json>'` is the single CLI lever for moving it through the funnel. The interesting transitions for vetting are below — pass `publish_status` as a string label (the integer code also works but the label is clearer for both humans and the audit log).
 
+An `open` sponsorship in negotiation progresses through three independent per-party **approval** fields: `brand_approval_status`, `channel_approval_status`, and `agency_approval_status`, each accepting `pending` / `approved` / `finished` (or `null`). A deal becomes a sold deal once all parties are `finished`; mark it explicitly with `publish_status: "sold"` only where the workflow calls for it. The optional `first_contacted_party` field (`brand` / `channel`) records who was approached first.
+
 | Action | Command | What it means |
 |---|---|---|
-| **Accept** (either side, in negotiation) | `tl sponsorships update <id> '{"publish_status": "pending"}'` | Moves the adlink to `PENDING` — both sides are working it but it's not yet sold. |
+| **Open for negotiation** | `tl sponsorships update <id> '{"publish_status": "open"}'` | Moves a matched adlink to `open` — it's now actively being worked by both sides. |
+| **Brand agrees** | `tl sponsorships update <id> '{"brand_approval_status": "approved"}'` | Records brand-side approval on an open deal (this is what makes a deal *committed*). |
+| **Channel agrees** | `tl sponsorships update <id> '{"channel_approval_status": "approved"}'` | Records channel-side approval on an open deal. |
 | **Mark sold** (deal finalised) | `tl sponsorships update <id> '{"publish_status": "sold"}'` | Final commercial step. Sets purchase semantics server-side. |
 | **Reject — Advertiser side** | `tl sponsorships update <id> '{"publish_status": "advertiser_reject"}'` | Maps to `DENY` ("Rejected by Advertiser"). Use when the *brand* turns the offer down. |
 | **Reject — Publisher side** | `tl sponsorships update <id> '{"publish_status": "publisher_reject"}'` | Maps to `REJECT` ("Rejected by Publisher"). Use when the *channel* turns the offer down. |
@@ -302,7 +306,7 @@ tl sponsorships update 98765 '{
 }'
 ```
 
-Full set of `publish_status` labels the CLI accepts: `proposed`, `unavailable`, `pending`, `sold`, `advertiser_reject`, `publisher_reject`, `proposal_approved`, `matched`, `outreach`, `agency_reject`. Numeric codes (0–9) are also accepted but labels are preferred.
+Full set of `publish_status` labels the CLI accepts: `sold`, `advertiser_reject`, `publisher_reject`, `matched`, `agency_reject`, `open`. Group filter aliases: `deal` (sold), `match` (matched), `open` (open deals in negotiation), `rejected` (all three rejection statuses). Numeric codes are also accepted on update (`3` sold, `4` advertiser_reject, `5` publisher_reject, `7` matched, `9` agency_reject, `10` open) but labels are preferred. Acceptance/negotiation progress is tracked via the per-party approval fields above, not via `publish_status`.
 
 #### Worked example: propose → reject
 

--- a/skills/tl/references/business-glossary.md
+++ b/skills/tl/references/business-glossary.md
@@ -12,10 +12,10 @@ Maps business terms to database concepts.
 | **Cost** | `adlink.cost` | What the channel earns |
 | **Price** | `adlink.price` | What the advertiser pays |
 | **Closed-lost** | `publish_status IN (4, 5, 9)` | All three rejection statuses |
-| **Open opportunity** | `publish_status IN (0, 2, 6, 7, 8)` | Pipeline — not revenue, not lost |
-| **Proposal Approved** | `publish_status = 6` | AM approved to show to brand — NOT brand approval. Internal gate only. |
-| **Pending** | `publish_status = 2` | Brand has agreed — this is the real high-intent signal |
-| **Weighted pipeline** | `SUM(weighted_price)` for open opps | Pre-calculated on save |
+| **Open opportunity** | `publish_status IN (7, 10)` | Pipeline (MATCHED, OPEN) — not revenue, not lost. Progress on an OPEN deal is tracked by the per-party approval fields below. |
+| **Per-party approval** | `brand_approval_status` / `channel_approval_status` / `agency_approval_status` on an OPEN deal | Each is NULL or 1=PENDING / 2=APPROVED / 3=FINISHED — approval to proceed is tracked per party on the OPEN deal. `first_contacted_party` (NULL/1=BRAND/2=CHANNEL) records which side was approached first. |
+| **Committed / bought** | `publish_status = 3` (SOLD), OR `publish_status = 10` AND `brand_approval_status IN (APPROVED, FINISHED)` | Brand has agreed — the real high-intent signal. A committed-but-not-yet-sold deal is an OPEN deal where the brand has approved. |
+| **Weighted pipeline** | `SUM(weighted_price)` for open opps | `weighted_price` is derived from the brand/channel approval combination on OPEN deals. |
 | **Ad is live** | `publish_date IS NOT NULL` | Until publish_date is set, ad is not on YouTube |
 | **Cancellation risk** | Sold but `publish_date IS NULL` | Sold deals without publish_date can still be canceled |
 | **Immediately bookable** | `is_tl_channel = true` | TPP channels — TL's closest partners. Fastest to respond, easiest to close, prefer when booking. |

--- a/skills/tl/references/postgres-schema.md
+++ b/skills/tl/references/postgres-schema.md
@@ -61,18 +61,18 @@ The profile table is tightly coupled with the brand table for media buyers, so m
 
 #### `publish_status` Constants
 
-| Value | Constant | Label | Pipeline Weight |
-|-------|----------|-------|----------------|
-| 0 | PREVIEW | Proposed | 10% |
-| 1 | UNAVAILABLE | Unavailable | — |
-| 2 | PENDING | Pending | 70% |
-| 3 | SOLD | Sold | — |
-| 4 | DENY | Rejected by Advertiser | 0% |
-| 5 | REJECT | Rejected by Publisher | 0% |
-| 6 | PROPOSAL_APPROVED | Proposal Approved | 25% |
-| 7 | MATCHED | Matched (default) | 1% |
-| 8 | OUTREACH | Reached Out | 5% |
-| 9 | REJECTED_AGENCY | Rejected by Agency | 0% |
+| Value | Constant | Label | Notes |
+|-------|----------|-------|-------|
+| 3 | SOLD | Sold | Realized revenue / concluded deal |
+| 4 | DENY | Rejected by Advertiser | Closed-lost |
+| 5 | REJECT | Rejected by Publisher | Closed-lost |
+| 7 | MATCHED | Matched (default) | Pre-negotiation initial stage |
+| 9 | REJECTED_AGENCY | Rejected by Agency | Closed-lost |
+| 10 | OPEN | Open | Active/in-negotiation deal; progress tracked via per-party approval fields |
+
+Live open deals are a single `OPEN` (10) status driven by three independent per-party approval fields: `brand_approval_status`, `channel_approval_status`, `agency_approval_status` (each `1 PENDING` / `2 APPROVED` / `3 FINISHED`, or NULL), plus `first_contacted_party` (`1 BRAND` / `2 CHANNEL`, or NULL).
+
+A deal is **committed** when it is SOLD, or OPEN with `brand_approval_status` in (APPROVED, FINISHED). `weighted_price` is derived from the brand/channel approval combination on OPEN deals.
 
 #### `rejection_reason` Constants
 
@@ -315,7 +315,7 @@ Note: separate from the adspot publisher relationship. Not always in sync.
 ```sql
 SELECT owner_sales_id, SUM(weighted_price) AS pipeline
 FROM thoughtleaders_adlink
-WHERE publish_status IN (0, 2, 6, 7, 8)
+WHERE publish_status IN (7, 10)
 GROUP BY owner_sales_id
 ORDER BY pipeline DESC
 LIMIT 100 OFFSET 0

--- a/src/tl_cli/commands/proposals.py
+++ b/src/tl_cli/commands/proposals.py
@@ -1,4 +1,4 @@
-"""tl proposals — Shortcut for proposed sponsorships."""
+"""tl proposals — Shortcut for open sponsorships in negotiation."""
 
 from typing import Optional
 
@@ -8,12 +8,12 @@ from tl_cli._typer_utils import AlphaSortedTyperGroup
 from tl_cli.commands.sponsorships import do_create, do_list, do_show
 from tl_cli.output.formatter import detect_format
 
-app = typer.Typer(cls=AlphaSortedTyperGroup, help="Proposals — matches proposed to both sides (shortcut for sponsorships status:proposal)")
+app = typer.Typer(cls=AlphaSortedTyperGroup, help="Proposals — open sponsorships in negotiation (shortcut for sponsorships status:open)")
 
 
 @app.callback(invoke_without_command=True)
 def proposals(ctx: typer.Context) -> None:
-    """Proposals — matches proposed to both sides."""
+    """Proposals — open sponsorships in negotiation."""
     if ctx.invoked_subcommand is None:
         ctx.invoke(list_cmd, args=[], json_output=False, csv_output=False, md_output=False, limit=50, offset=0)
 
@@ -35,7 +35,7 @@ def list_cmd(
         tl proposals list brand:"Nike"        # Filter proposals
     """
     fmt = detect_format(json_output, csv_output, md_output, toon_output)
-    do_list(args or [], fmt, limit, offset, default_status="proposal", title="Proposals")
+    do_list(args or [], fmt, limit, offset, default_status="open", title="Proposals")
 
 
 @app.command("show")
@@ -61,10 +61,10 @@ def create_cmd(
     json_output: bool = typer.Option(False, "--json", help="JSON output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
 ) -> None:
-    """Create a new proposal (free, no credits charged).
+    """Create a new sponsorship in matched status (free, no credits charged).
 
     Examples:
         tl proposals create --channel 1 --brand 2
     """
     fmt = detect_format(json_output, False, False, toon_output)
-    do_create(channel, brand, price, fmt, status="proposed")
+    do_create(channel, brand, price, fmt, status="matched")

--- a/src/tl_cli/commands/sponsorships.py
+++ b/src/tl_cli/commands/sponsorships.py
@@ -56,7 +56,7 @@ def do_list(
     _EQUIVALENT_STATUSES = {
         "deal": {"deal", "sold"},
         "match": {"match", "matched"},
-        "proposal": {"proposal", "proposed", "pending", "outreach"},
+        "open": {"open", "proposal"},
     }
 
     if default_status and "status" in filters:
@@ -197,7 +197,10 @@ def create_cmd(
     json_output: bool = typer.Option(False, "--json", help="JSON output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
 ) -> None:
-    """Create a new sponsorship proposal (free, no credits charged).
+    """Create a new sponsorship (free, no credits charged).
+
+    Creates the sponsorship in `matched` status by default; pass a different
+    `status` in the JSON body to override.
 
     Either pass --channel and --brand (with optional --price) as flags, or
     pass a JSON body as the positional argument — never both.
@@ -230,7 +233,7 @@ def create_cmd(
                 "[red]Error:[/red] JSON body must include channel_id and brand_id."
             )
             raise typer.Exit(1)
-        body.setdefault("status", "proposed")
+        body.setdefault("status", "matched")
         do_create_body(body, fmt)
         return
 
@@ -239,7 +242,7 @@ def create_cmd(
             "[red]Error:[/red] --channel and --brand are required (or pass a JSON body)."
         )
         raise typer.Exit(1)
-    do_create(channel, brand, price, fmt, status="proposed")
+    do_create(channel, brand, price, fmt, status="matched")
 
 
 @app.command("update")


### PR DESCRIPTION
Consumer-side update for the platform **approval-statuses** refactor: the linear open-stage `publish_status` chain (proposed / unavailable / pending / proposal_approved / outreach = 0/1/2/6/8) is replaced by a single **OPEN(10)** status driven by per-party **brand / channel / agency** approval fields. Branch rebased on current default branch.

**Changes**
- CLI create default `proposed`→`matched`; `proposal` shortcut alias → `open`; top-partnerships future-bookings now filter `open` by `brand_approval`.
- Rewrote tl skill / postgres-schema / business-glossary / tl-save-report docs + filterset schema to the new model.
- Per-party approval filters documented as first-class FilterSet properties; `committed` is a `filters_json` key.
- Removed retired publish_status ints from live-data docs; current-state-only wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
