### PR TITLE
Add tl-create-workflow skill

### DIFF
--- a/skills/tl-create-workflow/SKILL.md
+++ b/skills/tl-create-workflow/SKILL.md
@@ -48,11 +48,17 @@ A workflow is **not a new kind of object** — every stage IS a saved Report
   single most important rule and the #1 cause of broken hand-built workflows —
   see `references/workflow-model.md` (query vs list) and
   `references/pitfalls.md`. Never make stage 2+ a query.
-- **The CLI cannot create a workflow.** `tl` has no workflow command and the
-  `/api/workflows` endpoints are session-auth (not the CLI's Bearer). So this
-  skill **designs + sources + emits a blueprint**, and the user assembles it in
-  the web app via the steps in `references/creating-in-app.md`. Do not claim you
-  created a workflow — you prepared one.
+- **Creating the workflow.** A CLI create endpoint —
+  `POST /api/cli/v1/workflows/build` (Bearer) — turns the blueprint into a real
+  workflow in one atomic call (the Bearer twin of the web builder; ships with
+  backend PR #4192 and is invoked by a `tl workflow` command). A workflow made
+  this way is identical to an in-app one and appears in the web list/detail
+  immediately. **Until that endpoint + command are live**, this skill instead
+  **designs + sources + emits a blueprint** and the user assembles it in the web
+  app. Either path is in `references/creating-in-app.md`; the blueprint is the
+  exact input the endpoint needs, so nothing is wasted. Do not claim a workflow
+  was created unless the build call actually returned one — otherwise you
+  prepared a blueprint.
 - **Source with real data, never placeholder channels.** The entry stage must
   be filled from the index (delegate to `tl-keyword-research` /
   `tl channels find` / `tl recommender` / guide-brand research), never a made-up

--- a/skills/tl-create-workflow/SKILL.md
+++ b/skills/tl-create-workflow/SKILL.md
@@ -14,9 +14,9 @@ description: >
   "build an acquisition funnel". It designs the funnel from the goal + the TL
   methodology, sources the entry stage with real data (delegating to
   tl-keyword-research / tl channels / tl recommender / guide-brand research),
-  defines each stage as a query-or-list report, and hands back a create-ready
-  blueprint + the exact in-app assembly steps — the tl CLI has no workflow
-  endpoint, so the Workflow itself is assembled in the web app. Also answers
+  defines each stage as a query-or-list report, and creates it with
+  "tl workflow create" (or, until the backend endpoint is deployed, hands back the
+  create-ready blueprint + in-app assembly steps). Also answers
   HELP asks about how workflows work ("how do workflows work", "what's a
   query vs a list stage", "explain workflow stages") for free.
 ---
@@ -48,16 +48,15 @@ A workflow is **not a new kind of object** — every stage IS a saved Report
   single most important rule and the #1 cause of broken hand-built workflows —
   see `references/workflow-model.md` (query vs list) and
   `references/pitfalls.md`. Never make stage 2+ a query.
-- **Creating the workflow — the CLI cannot.** There is **no CLI (Bearer)
-  workflow endpoint and no `tl workflow` command**. Every `/api/workflows*` route
-  is session-authenticated (the web app's), not on the CLI's Bearer surface. So
-  this skill **designs + sources + emits a create-ready blueprint** and the user
-  stands the workflow up in the web app (Convert → Add stage) — see
-  `references/creating-in-app.md`. A Bearer CLI twin of the web builder
-  (`POST /api/cli/v1/workflows/build`) plus a `tl workflow` command would be a
-  natural future addition, and the blueprint is already its exact input — but
-  until they actually exist, never POST to that route and **never claim a
-  workflow was created**; you prepared a blueprint.
+- **Creating the workflow.** `tl workflow create --file <blueprint.json>` builds
+  it in one call — it POSTs `{name, report_type, steps}` to the Bearer endpoint
+  `/api/cli/v1/workflows/build` (the twin of the web builder). The command ships
+  in this repo; the endpoint ships with backend **PR #4192** — **until that is
+  deployed the command errors**, and the user stands the workflow up in the web
+  app from the blueprint (Convert → Add stage). Both paths are in
+  `references/creating-in-app.md`. **Never claim a workflow was created unless a
+  `tl workflow create` call actually returned one** — otherwise you prepared a
+  blueprint.
 - **Source with real data, never placeholder channels.** The entry stage must
   be filled from the index (delegate to `tl-keyword-research` /
   `tl channels find` / `tl recommender` / guide-brand research), never a made-up

--- a/skills/tl-create-workflow/SKILL.md
+++ b/skills/tl-create-workflow/SKILL.md
@@ -48,17 +48,16 @@ A workflow is **not a new kind of object** — every stage IS a saved Report
   single most important rule and the #1 cause of broken hand-built workflows —
   see `references/workflow-model.md` (query vs list) and
   `references/pitfalls.md`. Never make stage 2+ a query.
-- **Creating the workflow.** A CLI create endpoint —
-  `POST /api/cli/v1/workflows/build` (Bearer) — turns the blueprint into a real
-  workflow in one atomic call (the Bearer twin of the web builder; ships with
-  backend PR #4192 and is invoked by a `tl workflow` command). A workflow made
-  this way is identical to an in-app one and appears in the web list/detail
-  immediately. **Until that endpoint + command are live**, this skill instead
-  **designs + sources + emits a blueprint** and the user assembles it in the web
-  app. Either path is in `references/creating-in-app.md`; the blueprint is the
-  exact input the endpoint needs, so nothing is wasted. Do not claim a workflow
-  was created unless the build call actually returned one — otherwise you
-  prepared a blueprint.
+- **Creating the workflow — the CLI cannot.** There is **no CLI (Bearer)
+  workflow endpoint and no `tl workflow` command**. Every `/api/workflows*` route
+  is session-authenticated (the web app's), not on the CLI's Bearer surface. So
+  this skill **designs + sources + emits a create-ready blueprint** and the user
+  stands the workflow up in the web app (Convert → Add stage) — see
+  `references/creating-in-app.md`. A Bearer CLI twin of the web builder
+  (`POST /api/cli/v1/workflows/build`) plus a `tl workflow` command would be a
+  natural future addition, and the blueprint is already its exact input — but
+  until they actually exist, never POST to that route and **never claim a
+  workflow was created**; you prepared a blueprint.
 - **Source with real data, never placeholder channels.** The entry stage must
   be filled from the index (delegate to `tl-keyword-research` /
   `tl channels find` / `tl recommender` / guide-brand research), never a made-up

--- a/skills/tl-create-workflow/SKILL.md
+++ b/skills/tl-create-workflow/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: tl-create-workflow
+tl-blurb: design & stand up a sponsorship pipeline (workflow) from a goal
+description: >
+  Turn a sponsorship / sourcing goal into a structured, data-populated
+  **Workflow** — an ordered funnel of report-stages that channels (or brands)
+  move through, e.g. Sourced → Qualified → Get face on screen → Reach out →
+  Contacted → Sold. Invoke when the user wants to build or set up a workflow or
+  pipeline, design an outreach / acquisition funnel for a brand or campaign,
+  turn an existing report into a workflow, or organise channel sourcing into
+  stages. Triggers: "create a workflow", "build a pipeline / funnel", "set up
+  outreach for <brand>", "turn this report into a workflow", "organise my
+  sourcing into stages", "workflow for finding channels to sponsor <brand>",
+  "build an acquisition funnel". It designs the funnel from the goal + the TL
+  methodology, sources the entry stage with real data (delegating to
+  tl-keyword-research / tl channels / tl recommender / guide-brand research),
+  defines each stage as a query-or-list report, and hands back a create-ready
+  blueprint + the exact in-app assembly steps — the tl CLI has no workflow
+  endpoint, so the Workflow itself is assembled in the web app. Also answers
+  HELP asks about how workflows work ("how do workflows work", "what's a
+  query vs a list stage", "explain workflow stages") for free.
+---
+
+# tl-create-workflow — a sponsorship goal → a populated pipeline
+
+Turn a fuzzy goal ("I need channels to sponsor **Magic Spoon**", "set up our
+outreach funnel", "organise my sourcing") into a **Workflow**: an ordered chain
+of report-**stages** that entities move through, with the **entry stage already
+populated with the right channels** and every stage typed correctly. The value
+is not drawing boxes — it's (a) designing the funnel from the **ThoughtLeaders
+methodology** rather than a generic CRM template, (b) **sourcing the entry
+stage with real data** so the pipeline starts full, not empty, and (c) getting
+the **query-vs-list mechanics right** so the workflow doesn't break the way
+hand-built ones do.
+
+A workflow is **not a new kind of object** — every stage IS a saved Report
+(campaign), chained in order. Understanding that is the whole game; read
+`references/workflow-model.md` before you design anything.
+
+> `<SKILL_DIR>` below is this skill's directory (the one holding `SKILL.md`).
+
+## Hard rules
+
+- **A stage is a Report.** A workflow = ordered Reports linked by
+  `workflow_step_number`. There is no separate "stage" object. Design in terms
+  of reports.
+- **The entry stage is a QUERY; every later stage is a LIST.** This is the
+  single most important rule and the #1 cause of broken hand-built workflows —
+  see `references/workflow-model.md` (query vs list) and
+  `references/pitfalls.md`. Never make stage 2+ a query.
+- **The CLI cannot create a workflow.** `tl` has no workflow command and the
+  `/api/workflows` endpoints are session-auth (not the CLI's Bearer). So this
+  skill **designs + sources + emits a blueprint**, and the user assembles it in
+  the web app via the steps in `references/creating-in-app.md`. Do not claim you
+  created a workflow — you prepared one.
+- **Source with real data, never placeholder channels.** The entry stage must
+  be filled from the index (delegate to `tl-keyword-research` /
+  `tl channels find` / `tl recommender` / guide-brand research), never a made-up
+  list. An empty pipeline is a failed deliverable.
+- Do all data processing with the `utf-8` encoding explicitly in any script you
+  write.
+
+## Setup check
+
+```bash
+tl whoami        # confirms the CLI is authed and shows plan/limits
+```
+If this errors, tell the user to run `tl auth login` (or set `TL_API_KEY`).
+Sourcing stages needs intelligence access on the org's plan; if `tl whoami`
+shows no intelligence flag, say so — you can still design the funnel, but you
+can't populate it from the index.
+
+## When to invoke / skip
+
+**Invoke** when the user wants to **stand up a pipeline**: build/set up a
+workflow, design an outreach or acquisition funnel for a brand/campaign, turn a
+report into a workflow, or organise sourcing into stages.
+
+**Skip when:**
+- They just want to *find* channels/brands/videos → `tl channels find`,
+  `tl-keyword-research`, `tl recommender`. (You'll *use* these, but a lookup
+  alone isn't a workflow.)
+- They want to persist one flat list/report they already have →
+  `tl-save-report`.
+- They're asking about an **existing** workflow's data (counts, who's in which
+  stage) → query it with `tl` directly.
+
+## Help mode — explain workflows on request, for free
+
+When the user asks what a workflow is, how stages work, query vs list, or "how
+do I build one" as a *question* (not a request to build): **run nothing**. Read
+`references/workflow-model.md` (+ `references/pitfalls.md` for the gotchas) and
+explain, sized to the ask. Close by offering to design one. Mid-run questions
+get the same treatment — answer, then resume.
+
+## The build (you orchestrate; the tl CLI + sibling skills do the data work)
+
+| Stage | What happens | Tooling |
+|---|---|---|
+| 0 Frame | goal, entity type, funnel shape, stage list — interview, don't assume | you + `references/methodology.md` |
+| 1 Source the entry stage | fill stage 1 with the right channels/brands (a QUERY) | `tl-keyword-research` · `tl channels find` · `tl recommender` · guide-brand research |
+| 2 Define the stages | each stage as a report config (query for stage 1, lists after) | you + `references/workflow-model.md` |
+| 3 Blueprint | emit the create-ready plan: stage names, types, the entry filter, links | you |
+| 4 Assemble | the exact in-app steps to build it (Convert → Add stage → link) | `references/creating-in-app.md` |
+| 5 Deliver | blueprint + entry-stage report link + how to work the funnel | `tl-save-report` (for the entry report) |
+
+**Narrate the run** — one line per stage transition, and surface every
+assumption so the user can correct it. Sourcing spends credits (it's real ES
+work); say roughly how much as you go, exactly like `tl-keyword-research`.
+
+### Stage 0 — Frame the funnel (interview; never assume)
+
+Two things decide everything, and both are the user's:
+
+1. **The goal & entity.** What is this pipeline *for*, and does it move
+   **channels** (usual), **brands**, or **sponsorships**? "Find channels to
+   sponsor Magic Spoon" → a channel-acquisition funnel. "Work our brand
+   prospects" → a brand funnel. The entity type fixes the workflow's
+   `report_type` and can't be mixed later.
+2. **The funnel shape.** How many stages and what they mean. Don't invent a
+   generic "Lead → MQL → SQL" — derive it from the **ThoughtLeaders
+   methodology** (`references/methodology.md`): the real sourcing funnel is
+   *find the pool → qualify on value-vs-price → enrich (face-on-screen,
+   contacts) → outreach → pipeline (proposed/pending/sold)*. Offer the canonical
+   funnel below and let them cut/rename stages — the huddle's real stages are
+   good defaults:
+
+   > **Sourced** (query) → **Qualify** (list) → **Get face on screen** (list) →
+   > **Reach out** (list) → **Contacted** (list) → **Proposed** (list)
+
+   Stage names are just report titles — pick names the team will recognise
+   (they persist on the campaign). Fewer, meaningful stages beat many empty
+   ones.
+
+State the goal, entity, and stage list back to the user before sourcing
+anything.
+
+### Stage 1 — Source the entry stage (the QUERY)
+
+Stage 1 is the **pool**: the channels the funnel starts from, selected by a
+*filter* (a query), not an explicit list. Pick the sourcing path from the goal —
+this is where the methodology becomes data:
+
+- **Sponsor a specific brand / product** → find the brand's category and its
+  **guide brands** (proven sponsors / competitors), then their **winner
+  channels** (TRUE renewals — the real signal), then **look-alikes**. Use
+  `tl brands` research + `tl channels similar` / `tl recommender`.
+- **A topic / niche** ("cooking channels for a kitchenware brand") →
+  **`tl-keyword-research`** to turn the topic into a validated content filter +
+  the channels it selects. Take its `report_link` / filter set as stage 1.
+- **A known shortlist** → then stage 1 is really a *list*, and a workflow may be
+  overkill — say so; `tl-save-report` might be all they need.
+
+Deliver stage 1 as a **query report** (a filter set), and — because it's the
+entry — it's fine and correct for it to be a query. Populate it, eyeball the
+count and a sample, and confirm the breadth with the user (too broad → narrow
+the filter; too thin → widen), exactly like keyword-research's breadth check.
+
+### Stage 2 — Define the stages (query first, lists after)
+
+For each downstream stage, the report is a **list**: it starts empty and fills
+as the user bulk-selects entities in the previous stage and **Moves** them
+forward. You don't pre-populate lists — you just create the (empty) list
+reports with the right names and types.
+
+- **Types must alternate correctly:** stage 1 = query; stages 2..N = lists.
+  Re-check `references/workflow-model.md` if unsure how the platform infers
+  query-vs-list from the FilterSet.
+- **Columns per stage:** if a stage needs a specific column the team acts on
+  (e.g. *Face On Screen* on the "Get face on screen" stage, *Outreach email* on
+  "Reach out"), note it — columns are set per report.
+- **Linked reports (include/exclude), sparingly:** a stage can pull in another
+  report's entities (e.g. exclude "no email / captcha"). Keep this to **≤1–2
+  layers of nesting** — deep chains are the documented performance + confusion
+  trap (`references/pitfalls.md`). Prefer a flat stage over a clever nest.
+
+### Stage 3 — Emit the blueprint
+
+Hand the user a compact, create-ready plan:
+
+```
+Workflow: "Magic Spoon — channel sourcing"   (report_type: channels)
+  1. Sourced            [QUERY]  ← <entry filter summary> · ~<N> channels · <report_link>
+  2. Qualify            [list]   empty; move channels that pass value-vs-price
+  3. Get face on screen [list]   empty; column: Face On Screen
+  4. Reach out          [list]   empty; column: Outreach email; exclude → "No email / captcha"
+  5. Contacted          [list]   empty
+```
+
+Include the **entry report link** (from keyword-research / `tl reports create`)
+so stage 1 exists as a real, openable report before assembly.
+
+### Stage 4 — Assemble in the web app
+
+Workflows are built in-app (no CLI endpoint). Walk the user through
+`references/creating-in-app.md`:
+
+1. Open the **entry (Sourced) report** → **Convert to workflow** → name it. That
+   report becomes **stage 1**.
+2. **Add stage** for each downstream stage, in order, with the names from the
+   blueprint (they save on the campaign — renames persist).
+3. For any stage with a **linked report** (e.g. exclude "no email"), add it on
+   that stage — keep nesting shallow.
+4. Set per-stage **columns** where noted.
+5. Work the funnel: on a stage, **filter** (e.g. by *Face On Screen*),
+   **bulk-select**, **Move** to the next stage. Moving is non-destructive.
+
+### Stage 5 — Deliver
+
+Show: the funnel (stages, types, per-stage columns/links), the **entry-stage
+report link** (populated), and the one-paragraph "how to work this funnel"
+(filter → select → move). Offer to **save the entry report** via
+`tl-save-report` if it isn't already saved. Never save or create anything the
+user didn't ask for.
+
+## Cost
+
+Framing and blueprinting are free (no queries). **Sourcing stage 1 spends
+credits** — that's real ES work delegated to `tl-keyword-research` /
+`tl channels` / `tl recommender`; their own costs apply (keyword-research: ~10–20
+credits quick, ~60–120 deep). Run `tl describe show db` for live rates. The
+in-app assembly costs nothing (it's the user clicking in the platform).
+
+## Self-check before you finish
+
+1. You established the **goal**, the **entity type** (channels / brands /
+   sponsorships → the workflow's `report_type`), and the **stage list** with the
+   user — derived from the methodology, not a generic CRM funnel — and stated
+   them back before sourcing.
+2. **Stage 1 is a QUERY and it's populated** from real index data (not a
+   placeholder list), with its breadth confirmed against the goal (narrowed /
+   widened as needed). **Every stage after 1 is a LIST.** No stage 2+ is a query.
+3. Any **linked reports** are ≤1–2 nesting layers; you preferred a flat stage
+   over a deep nest, and flagged per-stage **columns** the team acts on.
+4. The blueprint is **create-ready**: named stages, correct types, the entry
+   filter summary + a working **report link**, and the in-app assembly steps.
+5. You were explicit that the **Workflow is assembled in the web app** (the CLI
+   can't create it) — you prepared it, you didn't claim to have created it.
+6. You narrated the run and its credit spend, and saved / created **nothing**
+   without the user's say-so.
+7. If the user requests a diagram of the funnel, create it as an SVG graphic.

--- a/skills/tl-create-workflow/references/creating-in-app.md
+++ b/skills/tl-create-workflow/references/creating-in-app.md
@@ -1,0 +1,57 @@
+# Assembling the workflow (in the web app)
+
+The `tl` CLI has **no workflow command**, and the workflow endpoints are
+session-authenticated (the CLI authenticates with a Bearer token against
+`/api/cli/v1/…`, a different surface). So the Workflow object itself is built in
+the web platform. This skill prepares everything up to that point (design +
+sourced entry report + blueprint); this file is the hand-off the user follows.
+
+## The create flow, today
+
+The platform creates a workflow by **converting an existing report** into a
+one-stage workflow, then adding stages:
+
+1. **Build the entry (Sourced) report first** — a *query* report populated by
+   this skill (via `tl-keyword-research`, `tl channels`, `tl recommender`, or
+   `tl reports create`). Save it (`tl-save-report` / `tl reports create`) so it
+   exists as an openable report.
+2. **Open that report in the platform → "Convert to workflow" → name it.** The
+   report becomes **stage 1**. (There is no "new blank workflow from scratch"
+   builder today — you start from a report and convert.)
+3. **Add each downstream stage** with the platform's **Add stage** control, in
+   order, using the names from the blueprint. Each new stage is an empty **list**
+   report. Stage names save on the campaign and persist across reloads.
+4. **Link supporting reports** on a stage where the blueprint calls for it
+   (include / exclude another report) — keep nesting shallow (≤1–2 layers).
+5. **Set per-stage columns** the team acts on (Face On Screen, Outreach email).
+6. **Work the funnel:** on a stage, filter the rows, bulk-select, and **Move**
+   the selection to the next stage. Move / Remove are non-destructive.
+
+## The endpoints (reference only — not callable from the CLI's Bearer auth)
+
+For context / future automation. All are session-auth under `/api/workflows`:
+
+| Action | Request |
+|--------|---------|
+| Convert a report → workflow | `POST /api/workflows` · `{ campaignId, workflowName }` → new 1-stage workflow |
+| Add a stage | `POST /api/workflows/add-step` |
+| Delete a stage | `DELETE /api/workflows/delete-step` |
+| Rename the workflow | `PATCH /api/workflows/:id` · `{ name }` |
+| Delete the workflow (owner only) | `DELETE /api/workflows/:id` |
+| Fetch a workflow + stages | `GET /api/workflows/:id` |
+| Link a report to a stage / move entities | `POST` to the stage filterset's `add_relation` |
+
+**Known limitation to flag to the user:** because create only *converts an
+existing report*, there is no single "create a full multi-stage workflow (name +
+stages + links) in one call". Building the funnel is convert-then-add-stage,
+one stage at a time, in the UI. If a from-scratch multi-stage builder ships
+later (or a CLI endpoint is added), this skill's blueprint is already the exact
+input it would need — so nothing is wasted.
+
+## What to hand the user
+
+- The **entry report link** (populated, openable).
+- The **blueprint** (stage names, types, per-stage columns, any linked reports).
+- These **six assembly steps**, condensed to their situation.
+- The one-line "how to work the funnel": *filter a stage → select → Move to
+  next.*

--- a/skills/tl-create-workflow/references/creating-in-app.md
+++ b/skills/tl-create-workflow/references/creating-in-app.md
@@ -1,83 +1,95 @@
 # Creating the workflow
 
-**The `tl` CLI cannot create a workflow.** Every `/api/workflows*` route is
-**session-authenticated** (the web app's), so it's off the CLI's Bearer surface —
-there is no `/api/cli/v1/workflows/*` route and no `tl workflow` command today.
-So this skill **designs + sources + emits a create-ready blueprint**, and the
-user stands the workflow up in the **web app** from that blueprint. A workflow
-built there is the same `Workflow` / stage-`Campaign` / `FilterSet` objects the
-rest of the platform uses.
+**`tl workflow create` builds the workflow from a blueprint in one call** — it
+POSTs `{name, report_type, steps}` to the Bearer endpoint
+`/api/cli/v1/workflows/build` (the twin of the web "New Workflow" builder). The
+result is the same `Workflow` / stage-`Campaign` / `FilterSet` objects the rest of
+the platform uses, so it shows up in the web app's workflow list/detail
+immediately, where the team moves / edits / duplicates it.
 
-## Assemble it in the web app (the actual path)
+> **Availability.** The `tl workflow` command ships in this repo; the endpoint it
+> calls ships with backend **thoughtleaders PR #4192** (`create_full_workflow`).
+> Until that backend change is deployed, `tl workflow create` returns an error —
+> use the **manual in-app assembly** at the bottom of this file. The blueprint is
+> the exact same input either way, so nothing is wasted.
+
+## Create it directly (preferred)
 
 1. **Build + save the entry (Sourced) report first**, so it exists with an **id**.
    It's a *query* report populated by this skill (`tl-keyword-research`,
    `tl channels`, `tl recommender`, or `tl reports create`) and saved
    (`tl-save-report` / `tl reports create`). This is the only stage that starts
    with data, and it must be a saved **query** so the stage stays live.
-2. Open the saved entry report → **Convert to workflow** → name it. It becomes
-   **stage 1**.
-3. **Add stage** for each downstream stage, in blueprint order (each is an empty
-   **list** channels move into; names persist across reloads).
-4. **Link** supporting include/exclude reports where the blueprint calls for it
-   (nesting ≤1–2 layers).
-5. Set per-stage **columns** the team acts on (Face On Screen, Outreach email).
-6. **Work the funnel:** on a stage, filter the rows → bulk-select → **Move** to
-   the next stage. Move / Remove are non-destructive; moved channels leave the
-   source stage.
+2. **Write the blueprint to a file** and run `tl workflow create`:
 
-## The blueprint (the create-ready plan you hand over)
+   ```bash
+   tl workflow create --file blueprint.json        # add --yes to skip the confirm
+   ```
 
-Emit the plan as name + `report_type` + an ordered list of stages. It maps
-one-to-one onto the in-app steps above (and would be the exact body of a future
-create endpoint — see below):
+   `blueprint.json`:
 
-```json
-{
-  "name": "<workflow name>",
-  "report_type": 3,
-  "steps": [
-    { "title": "Sourced",            "include_report_ids": [<entryReportId>], "exclude_report_ids": [] },
-    { "title": "Qualify",            "include_report_ids": [], "exclude_report_ids": [] },
-    { "title": "Get face on screen", "include_report_ids": [], "exclude_report_ids": [] },
-    { "title": "Reach out",          "include_report_ids": [], "exclude_report_ids": [] }
-  ]
-}
-```
+   ```json
+   {
+     "name": "Q3 Creator Outreach",
+     "report_type": 3,
+     "steps": [
+       { "title": "Sourced",            "include_report_ids": [<entryReportId>], "exclude_report_ids": [] },
+       { "title": "Qualify",            "include_report_ids": [], "exclude_report_ids": [] },
+       { "title": "Get face on screen", "include_report_ids": [], "exclude_report_ids": [] },
+       { "title": "Reach out",          "include_report_ids": [], "exclude_report_ids": [] }
+     ]
+   }
+   ```
 
-- `report_type`: **1** content · **2** brands · **3** channels · **8** sponsorships.
-- Stages are ordered; the first is the entry stage, the rest are empty **lists**
-  channels move into. Keep any linked-report nesting shallow (≤1–2).
+   - `report_type`: **1** content · **2** brands · **3** channels · **8** sponsorships.
+   - Stages are created **in order**; the first is the entry stage (link the saved
+     query report via `include_report_ids`), the rest are empty **lists** channels
+     move into. Keep any linked-report nesting shallow (≤1–2).
+   - Only reports you may edit are linked (others are dropped); the workflow is
+     owned by you. One atomic call creates the workflow + stage campaigns +
+     include/exclude report links + the exclude-earlier-stages chaining.
+   - Use `--config '<json>'` for inline JSON, or `--name` / `--report-type` to
+     supply/override those fields. `--json` / `--toon` for machine output.
+3. The command prints the new workflow **id** and an **"Open in app"** link
+   (`/#/workflows/<report_type>/<id>`). Hand that to the user to work the funnel:
+   on a stage, filter → bulk-select → **Move** to the next stage (Move / Remove
+   are non-destructive; moved channels leave the source stage).
 
 ## The endpoints (reference)
 
-All are the web app's **session-authenticated** management routes — none is on
-the CLI's Bearer surface, so the CLI/agent cannot call them:
-
 | Action | Request | Auth |
 |--------|---------|------|
+| **Build a full workflow** (`tl workflow create`) | `POST /api/cli/v1/workflows/build` · `{ name, report_type, steps[] }` | **Bearer (CLI)** |
 | Convert one report → 1-stage workflow | `POST /api/workflows` · `{ campaignId, workflowName }` | session |
-| Build a full workflow (name + stages + links) — the web "New Workflow" builder | `POST /api/workflows/build` · `{ name, report_type, steps[] }` | session (ships with thoughtleaders **PR #4192**, `create_full_workflow`) |
 | Add a stage | `POST /api/workflows/add-step` · `{ campaignTitle, workflowId }` | session |
-| Delete a stage | `DELETE /api/workflows/delete-step?stepId=` | session |
-| Rename / delete the workflow (delete is owner-only) | `PATCH` / `DELETE /api/workflows/:id` | session |
+| Delete a stage (owner only) | `DELETE /api/workflows/delete-step?stepId=` | session |
+| Rename / delete the workflow | `PATCH` / `DELETE /api/workflows/:id` | session |
 | Fetch a workflow + stages | `GET /api/workflows/:id` | session |
 | Link a report / move entities on a stage | `PATCH` the stage filterset's `add_relation` action | session |
 
-## Future: a direct CLI create (does not exist yet)
+Only the **build** endpoint is on the CLI's Bearer surface; the rest are the web
+app's session-authenticated management routes (used from the web UI).
 
-A Bearer twin of the web builder — `POST /api/cli/v1/workflows/build`, invoked by
-a `tl workflow` command — would let this skill create the workflow in one atomic
-call (workflow + stage campaigns + include/exclude report links + the
-exclude-earlier-stages chaining, returning the workflow `id`), linking only
-reports the caller may edit and owning the result. The blueprint above is already
-its exact input, so nothing is wasted when it lands. **It is not implemented
-today — do not POST to it, and never claim a workflow was created unless a call
-actually returned one.**
+## Assemble it in the web app (fallback until the endpoint is live)
+
+If the build endpoint isn't deployed yet, the user stands the workflow up from
+the blueprint by hand — same design, more clicks:
+
+1. Open the saved entry report → **Convert to workflow** → name it. It becomes
+   **stage 1**.
+2. **Add stage** for each downstream stage, in blueprint order (each is an empty
+   **list**; names persist across reloads).
+3. **Link** supporting include/exclude reports where the blueprint calls for it
+   (nesting ≤1–2 layers).
+4. Set per-stage **columns** the team acts on (Face On Screen, Outreach email).
+5. **Work the funnel:** on a stage, filter → select → **Move** to the next stage.
 
 ## What to hand the user
 
 - The **entry report link** (populated, openable).
-- The **blueprint + in-app assembly steps** (Convert → Add stage → link → set
-  columns).
+- Either the **"Open in app" workflow link** (from `tl workflow create`) or the
+  **blueprint + in-app assembly steps** (fallback).
 - The one-line "how to work the funnel": *filter a stage → select → Move to next.*
+
+Never claim a workflow was created unless a `tl workflow create` call actually
+returned one — otherwise you prepared a blueprint.

--- a/skills/tl-create-workflow/references/creating-in-app.md
+++ b/skills/tl-create-workflow/references/creating-in-app.md
@@ -1,57 +1,89 @@
-# Assembling the workflow (in the web app)
+# Creating the workflow
 
-The `tl` CLI has **no workflow command**, and the workflow endpoints are
-session-authenticated (the CLI authenticates with a Bearer token against
-`/api/cli/v1/…`, a different surface). So the Workflow object itself is built in
-the web platform. This skill prepares everything up to that point (design +
-sourced entry report + blueprint); this file is the hand-off the user follows.
+There is a **CLI create endpoint** so this skill's blueprint becomes a real
+workflow directly — no hand-off required:
 
-## The create flow, today
+```
+POST /api/cli/v1/workflows/build      (Bearer auth — the CLI's surface)
+```
 
-The platform creates a workflow by **converting an existing report** into a
-one-stage workflow, then adding stages:
+A workflow created this way is **identical to one built in the web app** (same
+`Workflow` / stage-`Campaign` / `FilterSet` objects) and shows up in the web app's
+workflow list + detail immediately, where the team moves / edits / duplicates it.
 
-1. **Build the entry (Sourced) report first** — a *query* report populated by
-   this skill (via `tl-keyword-research`, `tl channels`, `tl recommender`, or
-   `tl reports create`). Save it (`tl-save-report` / `tl reports create`) so it
-   exists as an openable report.
-2. **Open that report in the platform → "Convert to workflow" → name it.** The
-   report becomes **stage 1**. (There is no "new blank workflow from scratch"
-   builder today — you start from a report and convert.)
-3. **Add each downstream stage** with the platform's **Add stage** control, in
-   order, using the names from the blueprint. Each new stage is an empty **list**
-   report. Stage names save on the campaign and persist across reloads.
-4. **Link supporting reports** on a stage where the blueprint calls for it
-   (include / exclude another report) — keep nesting shallow (≤1–2 layers).
-5. **Set per-stage columns** the team acts on (Face On Screen, Outreach email).
-6. **Work the funnel:** on a stage, filter the rows, bulk-select, and **Move**
-   the selection to the next stage. Move / Remove are non-destructive.
+> **Prerequisites.** The endpoint ships with backend **thoughtleaders PR #4192**
+> (`create_full_workflow`, of which this is the Bearer twin) and is invoked by a
+> `tl workflow` command that POSTs to it. Until both are live, use the **manual
+> in-app assembly** at the bottom of this file — the blueprint is the exact same
+> input either way, so nothing changes for the user-facing design work.
 
-## The endpoints (reference only — not callable from the CLI's Bearer auth)
+## Create it directly (preferred)
 
-For context / future automation. All are session-auth under `/api/workflows`:
+1. **Build + save the entry (Sourced) report first.** It's a *query* report
+   populated by this skill (`tl-keyword-research`, `tl channels`, `tl recommender`,
+   or `tl reports create`) and saved (`tl-save-report` / `tl reports create`) so it
+   exists with an **id**. This is the only stage that starts with data; it must be
+   a saved query so the stage stays live.
+2. **POST the blueprint** to `/api/cli/v1/workflows/build`:
 
-| Action | Request |
-|--------|---------|
-| Convert a report → workflow | `POST /api/workflows` · `{ campaignId, workflowName }` → new 1-stage workflow |
-| Add a stage | `POST /api/workflows/add-step` · `{ campaignTitle, workflowId }` |
-| Delete a stage (step owner only) | `DELETE /api/workflows/delete-step?stepId=` |
-| Rename the workflow | `PATCH /api/workflows/:id` · `{ name }` |
-| Delete the workflow | `DELETE /api/workflows/:id` |
-| Fetch a workflow + stages | `GET /api/workflows/:id` |
-| Link a report to a stage / move entities | `PATCH` the stage filterset's `add_relation` action |
+   ```json
+   {
+     "name": "<workflow name>",
+     "report_type": 3,
+     "steps": [
+       { "title": "Sourced",         "include_report_ids": [<entryReportId>], "exclude_report_ids": [] },
+       { "title": "Qualify",         "include_report_ids": [], "exclude_report_ids": [] },
+       { "title": "Get face on screen", "include_report_ids": [], "exclude_report_ids": [] },
+       { "title": "Reach out",       "include_report_ids": [], "exclude_report_ids": [] }
+     ]
+   }
+   ```
 
-**Known limitation to flag to the user:** because create only *converts an
-existing report*, there is no single "create a full multi-stage workflow (name +
-stages + links) in one call". Building the funnel is convert-then-add-stage,
-one stage at a time, in the UI. If a from-scratch multi-stage builder ships
-later (or a CLI endpoint is added), this skill's blueprint is already the exact
-input it would need — so nothing is wasted.
+   - `report_type`: **1** content · **2** brands · **3** channels · **8** sponsorships.
+   - Steps are created **in order**; the first is the entry stage, the rest are
+     empty **lists** channels move into. Keep any linked-report nesting shallow (≤1–2).
+   - Only reports you may edit are linked (others are silently dropped); the
+     workflow is owned by the caller.
+   - One atomic call creates the workflow + stage campaigns + include/exclude
+     report links + the exclude-earlier-stages chaining, and returns the workflow
+     (with its `id`).
+3. **Hand the user the "Open in app" link** from the response breadcrumb
+   (`/#/workflows/<report_type>/<id>`) to start working the funnel: on a stage,
+   filter the rows → bulk-select → **Move** to the next stage (Move / Remove are
+   non-destructive; moved channels leave the source stage).
+
+## The endpoints (reference)
+
+| Action | Request | Auth |
+|--------|---------|------|
+| **Build a full workflow (name + stages + links)** | `POST /api/cli/v1/workflows/build` · `{ name, report_type, steps[] }` | **Bearer (CLI)** |
+| Convert one report → 1-stage workflow | `POST /api/workflows` · `{ campaignId, workflowName }` | session |
+| Add a stage | `POST /api/workflows/add-step` · `{ campaignTitle, workflowId }` | session |
+| Delete a stage (owner only) | `DELETE /api/workflows/delete-step?stepId=` | session |
+| Rename / delete the workflow | `PATCH` / `DELETE /api/workflows/:id` | session |
+| Fetch a workflow + stages | `GET /api/workflows/:id` | session |
+| Link a report / move entities on a stage | `PATCH` the stage filterset's `add_relation` action | session |
+
+Only the **build** endpoint is on the CLI's Bearer surface; the rest are the web
+app's session-authenticated management routes.
+
+## Or assemble it in the web app (manual fallback)
+
+If the build endpoint / `tl workflow` command isn't live yet, the user assembles
+it from the blueprint by hand:
+
+1. Open the saved entry report → **Convert to workflow** → name it. It becomes
+   **stage 1**.
+2. **Add stage** for each downstream stage, in blueprint order (each is an empty
+   list; names persist across reloads).
+3. **Link** supporting include/exclude reports where the blueprint calls for it
+   (nesting ≤1–2 layers).
+4. Set per-stage **columns** the team acts on (Face On Screen, Outreach email).
+5. **Work the funnel:** filter a stage → select → **Move** to the next stage.
 
 ## What to hand the user
 
 - The **entry report link** (populated, openable).
-- The **blueprint** (stage names, types, per-stage columns, any linked reports).
-- These **six assembly steps**, condensed to their situation.
-- The one-line "how to work the funnel": *filter a stage → select → Move to
-  next.*
+- Either the **"Open in app" workflow link** (direct-create path) or the
+  **blueprint + assembly steps** (manual fallback).
+- The one-line "how to work the funnel": *filter a stage → select → Move to next.*

--- a/skills/tl-create-workflow/references/creating-in-app.md
+++ b/skills/tl-create-workflow/references/creating-in-app.md
@@ -62,8 +62,8 @@ immediately, where the team moves / edits / duplicates it.
 | **Build a full workflow** (`tl workflow create`) | `POST /api/cli/v1/workflows/build` · `{ name, report_type, steps[] }` | **Bearer (CLI)** |
 | Convert one report → 1-stage workflow | `POST /api/workflows` · `{ campaignId, workflowName }` | session |
 | Add a stage | `POST /api/workflows/add-step` · `{ campaignTitle, workflowId }` | session |
-| Delete a stage (owner only) | `DELETE /api/workflows/delete-step?stepId=` | session |
-| Rename / delete the workflow | `PATCH` / `DELETE /api/workflows/:id` | session |
+| Delete a stage (any same-org collaborator) | `DELETE /api/workflows/delete-step?stepId=` | session |
+| Rename / delete the workflow (delete is owner-only) | `PATCH` / `DELETE /api/workflows/:id` | session |
 | Fetch a workflow + stages | `GET /api/workflows/:id` | session |
 | Link a report / move entities on a stage | `PATCH` the stage filterset's `add_relation` action | session |
 

--- a/skills/tl-create-workflow/references/creating-in-app.md
+++ b/skills/tl-create-workflow/references/creating-in-app.md
@@ -1,89 +1,83 @@
 # Creating the workflow
 
-There is a **CLI create endpoint** so this skill's blueprint becomes a real
-workflow directly — no hand-off required:
+**The `tl` CLI cannot create a workflow.** Every `/api/workflows*` route is
+**session-authenticated** (the web app's), so it's off the CLI's Bearer surface —
+there is no `/api/cli/v1/workflows/*` route and no `tl workflow` command today.
+So this skill **designs + sources + emits a create-ready blueprint**, and the
+user stands the workflow up in the **web app** from that blueprint. A workflow
+built there is the same `Workflow` / stage-`Campaign` / `FilterSet` objects the
+rest of the platform uses.
 
+## Assemble it in the web app (the actual path)
+
+1. **Build + save the entry (Sourced) report first**, so it exists with an **id**.
+   It's a *query* report populated by this skill (`tl-keyword-research`,
+   `tl channels`, `tl recommender`, or `tl reports create`) and saved
+   (`tl-save-report` / `tl reports create`). This is the only stage that starts
+   with data, and it must be a saved **query** so the stage stays live.
+2. Open the saved entry report → **Convert to workflow** → name it. It becomes
+   **stage 1**.
+3. **Add stage** for each downstream stage, in blueprint order (each is an empty
+   **list** channels move into; names persist across reloads).
+4. **Link** supporting include/exclude reports where the blueprint calls for it
+   (nesting ≤1–2 layers).
+5. Set per-stage **columns** the team acts on (Face On Screen, Outreach email).
+6. **Work the funnel:** on a stage, filter the rows → bulk-select → **Move** to
+   the next stage. Move / Remove are non-destructive; moved channels leave the
+   source stage.
+
+## The blueprint (the create-ready plan you hand over)
+
+Emit the plan as name + `report_type` + an ordered list of stages. It maps
+one-to-one onto the in-app steps above (and would be the exact body of a future
+create endpoint — see below):
+
+```json
+{
+  "name": "<workflow name>",
+  "report_type": 3,
+  "steps": [
+    { "title": "Sourced",            "include_report_ids": [<entryReportId>], "exclude_report_ids": [] },
+    { "title": "Qualify",            "include_report_ids": [], "exclude_report_ids": [] },
+    { "title": "Get face on screen", "include_report_ids": [], "exclude_report_ids": [] },
+    { "title": "Reach out",          "include_report_ids": [], "exclude_report_ids": [] }
+  ]
+}
 ```
-POST /api/cli/v1/workflows/build      (Bearer auth — the CLI's surface)
-```
 
-A workflow created this way is **identical to one built in the web app** (same
-`Workflow` / stage-`Campaign` / `FilterSet` objects) and shows up in the web app's
-workflow list + detail immediately, where the team moves / edits / duplicates it.
-
-> **Prerequisites.** The endpoint ships with backend **thoughtleaders PR #4192**
-> (`create_full_workflow`, of which this is the Bearer twin) and is invoked by a
-> `tl workflow` command that POSTs to it. Until both are live, use the **manual
-> in-app assembly** at the bottom of this file — the blueprint is the exact same
-> input either way, so nothing changes for the user-facing design work.
-
-## Create it directly (preferred)
-
-1. **Build + save the entry (Sourced) report first.** It's a *query* report
-   populated by this skill (`tl-keyword-research`, `tl channels`, `tl recommender`,
-   or `tl reports create`) and saved (`tl-save-report` / `tl reports create`) so it
-   exists with an **id**. This is the only stage that starts with data; it must be
-   a saved query so the stage stays live.
-2. **POST the blueprint** to `/api/cli/v1/workflows/build`:
-
-   ```json
-   {
-     "name": "<workflow name>",
-     "report_type": 3,
-     "steps": [
-       { "title": "Sourced",         "include_report_ids": [<entryReportId>], "exclude_report_ids": [] },
-       { "title": "Qualify",         "include_report_ids": [], "exclude_report_ids": [] },
-       { "title": "Get face on screen", "include_report_ids": [], "exclude_report_ids": [] },
-       { "title": "Reach out",       "include_report_ids": [], "exclude_report_ids": [] }
-     ]
-   }
-   ```
-
-   - `report_type`: **1** content · **2** brands · **3** channels · **8** sponsorships.
-   - Steps are created **in order**; the first is the entry stage, the rest are
-     empty **lists** channels move into. Keep any linked-report nesting shallow (≤1–2).
-   - Only reports you may edit are linked (others are silently dropped); the
-     workflow is owned by the caller.
-   - One atomic call creates the workflow + stage campaigns + include/exclude
-     report links + the exclude-earlier-stages chaining, and returns the workflow
-     (with its `id`).
-3. **Hand the user the "Open in app" link** from the response breadcrumb
-   (`/#/workflows/<report_type>/<id>`) to start working the funnel: on a stage,
-   filter the rows → bulk-select → **Move** to the next stage (Move / Remove are
-   non-destructive; moved channels leave the source stage).
+- `report_type`: **1** content · **2** brands · **3** channels · **8** sponsorships.
+- Stages are ordered; the first is the entry stage, the rest are empty **lists**
+  channels move into. Keep any linked-report nesting shallow (≤1–2).
 
 ## The endpoints (reference)
 
+All are the web app's **session-authenticated** management routes — none is on
+the CLI's Bearer surface, so the CLI/agent cannot call them:
+
 | Action | Request | Auth |
 |--------|---------|------|
-| **Build a full workflow (name + stages + links)** | `POST /api/cli/v1/workflows/build` · `{ name, report_type, steps[] }` | **Bearer (CLI)** |
 | Convert one report → 1-stage workflow | `POST /api/workflows` · `{ campaignId, workflowName }` | session |
+| Build a full workflow (name + stages + links) — the web "New Workflow" builder | `POST /api/workflows/build` · `{ name, report_type, steps[] }` | session (ships with thoughtleaders **PR #4192**, `create_full_workflow`) |
 | Add a stage | `POST /api/workflows/add-step` · `{ campaignTitle, workflowId }` | session |
-| Delete a stage (owner only) | `DELETE /api/workflows/delete-step?stepId=` | session |
-| Rename / delete the workflow | `PATCH` / `DELETE /api/workflows/:id` | session |
+| Delete a stage | `DELETE /api/workflows/delete-step?stepId=` | session |
+| Rename / delete the workflow (delete is owner-only) | `PATCH` / `DELETE /api/workflows/:id` | session |
 | Fetch a workflow + stages | `GET /api/workflows/:id` | session |
 | Link a report / move entities on a stage | `PATCH` the stage filterset's `add_relation` action | session |
 
-Only the **build** endpoint is on the CLI's Bearer surface; the rest are the web
-app's session-authenticated management routes.
+## Future: a direct CLI create (does not exist yet)
 
-## Or assemble it in the web app (manual fallback)
-
-If the build endpoint / `tl workflow` command isn't live yet, the user assembles
-it from the blueprint by hand:
-
-1. Open the saved entry report → **Convert to workflow** → name it. It becomes
-   **stage 1**.
-2. **Add stage** for each downstream stage, in blueprint order (each is an empty
-   list; names persist across reloads).
-3. **Link** supporting include/exclude reports where the blueprint calls for it
-   (nesting ≤1–2 layers).
-4. Set per-stage **columns** the team acts on (Face On Screen, Outreach email).
-5. **Work the funnel:** filter a stage → select → **Move** to the next stage.
+A Bearer twin of the web builder — `POST /api/cli/v1/workflows/build`, invoked by
+a `tl workflow` command — would let this skill create the workflow in one atomic
+call (workflow + stage campaigns + include/exclude report links + the
+exclude-earlier-stages chaining, returning the workflow `id`), linking only
+reports the caller may edit and owning the result. The blueprint above is already
+its exact input, so nothing is wasted when it lands. **It is not implemented
+today — do not POST to it, and never claim a workflow was created unless a call
+actually returned one.**
 
 ## What to hand the user
 
 - The **entry report link** (populated, openable).
-- Either the **"Open in app" workflow link** (direct-create path) or the
-  **blueprint + assembly steps** (manual fallback).
+- The **blueprint + in-app assembly steps** (Convert → Add stage → link → set
+  columns).
 - The one-line "how to work the funnel": *filter a stage → select → Move to next.*

--- a/skills/tl-create-workflow/references/creating-in-app.md
+++ b/skills/tl-create-workflow/references/creating-in-app.md
@@ -34,12 +34,12 @@ For context / future automation. All are session-auth under `/api/workflows`:
 | Action | Request |
 |--------|---------|
 | Convert a report → workflow | `POST /api/workflows` · `{ campaignId, workflowName }` → new 1-stage workflow |
-| Add a stage | `POST /api/workflows/add-step` |
-| Delete a stage | `DELETE /api/workflows/delete-step` |
+| Add a stage | `POST /api/workflows/add-step` · `{ campaignTitle, workflowId }` |
+| Delete a stage (step owner only) | `DELETE /api/workflows/delete-step?stepId=` |
 | Rename the workflow | `PATCH /api/workflows/:id` · `{ name }` |
-| Delete the workflow (owner only) | `DELETE /api/workflows/:id` |
+| Delete the workflow | `DELETE /api/workflows/:id` |
 | Fetch a workflow + stages | `GET /api/workflows/:id` |
-| Link a report to a stage / move entities | `POST` to the stage filterset's `add_relation` |
+| Link a report to a stage / move entities | `PATCH` the stage filterset's `add_relation` action |
 
 **Known limitation to flag to the user:** because create only *converts an
 existing report*, there is no single "create a full multi-stage workflow (name +

--- a/skills/tl-create-workflow/references/methodology.md
+++ b/skills/tl-create-workflow/references/methodology.md
@@ -1,0 +1,70 @@
+# Funnel design — the ThoughtLeaders methodology, not a generic CRM
+
+Don't design a workflow like a generic sales CRM ("Lead → MQL → SQL → Won").
+Design it from how ThoughtLeaders actually sources and closes sponsorships. The
+funnel stages fall out of the methodology.
+
+## The sourcing methodology (how the pool is found)
+
+The core play for finding the right channels for a brand:
+
+1. **Identify the brands** — through competitor research and **Guide Brands**
+   (brands that are *proven* sponsors in the category). A guide brand is a
+   working example of "who already pays to sponsor this kind of content".
+2. **Find the winner channels** — the channels those guide brands *renewed*
+   with. A **TRUE renewal** (the brand came back and paid again) is the real
+   signal that the channel converts, not a vanity metric.
+3. **Find look-alike channels** — channels similar to the winners (same
+   audience/niche/shape) that haven't been booked yet. This is the addressable
+   pool.
+4. **Analyse value vs price** — for each candidate, is the projected value
+   (views, audience fit) worth the price? This is the qualification gate.
+
+The entry stage of a workflow is the output of steps 1–3 (the look-alike pool),
+expressed as a **query**. Qualification (step 4) is the first downstream list
+stage.
+
+## Terminology to keep straight (TL uses its own words)
+
+- **Brands** = the sponsors (usually companies, sometimes a single product).
+- **Channels** = the creators being sponsored (YouTube channels, sometimes
+  podcasts).
+- **Sponsorship** is the umbrella; it narrows through a funnel of its own:
+  *Sponsorships ⊃ Matches ⊃ Proposals ⊃ Deals (sold)*.
+- Pricing words: **PV** = Projected Views (a pricing estimate); **VG** = View
+  Guarantee (the contractual floor). Don't invent CPM/"margin" language — TL
+  says **Net revenue** / **TL profit**, and avoid "flight" / "hero channel".
+- **Send date** = the expected publication date of a sponsored video.
+- Two channel networks exist: **MSN** (the large ~11K opted-in Media Selling
+  Network) and **TPP** (the small ~169 directly-managed VIP channels). Sourcing
+  usually works over MSN; enrichment tasks ("get face on screen") are often
+  assigned to MSN managers.
+
+## The canonical acquisition funnel
+
+A good default channel-acquisition workflow, with each stage's type and the
+column the team acts on. Offer this, then let the user cut / rename / reorder.
+
+| # | Stage | Type | What it means | Acted-on column |
+|---|-------|------|---------------|-----------------|
+| 1 | **Sourced** | query | The pool: look-alike channels for the brand's guide-brand winners (or a topic filter). | — |
+| 2 | **Qualify** | list | Passed value-vs-price (and, if relevant, an authenticity check). | Projected views / price |
+| 3 | **Get face on screen** | list | Assigned to MSN managers to fill in face-on-screen + enrich. | Face On Screen |
+| 4 | **Reach out** | list | Has an outreach email; ready to contact. | Outreach email |
+| 5 | **Contacted** | list | Outreach sent. | — |
+| 6 | **Proposed** | list | A proposal is out. | — |
+
+Notes:
+- Stages 5–6 mirror the sponsorship sub-funnel (Match → Proposal → Deal); stop
+  wherever the team's process stops. Don't add stages the team won't work.
+- For a **brand-prospecting** workflow (report_type = brands) the shape rebases:
+  *Prospects (query: brands in a category / competitors of a guide brand) →
+  Qualified → Pitching → Won*.
+
+## Sizing the pool (breadth)
+
+There is no universal right number. A niche brand with a few dozen good
+look-alikes is a complete answer; a broad consumer brand returning a few dozen
+is probably too narrow. State your breadth judgement and offer to narrow/widen —
+exactly the calibration `tl-keyword-research` does. The pool is the query stage;
+everything downstream is a subset of it.

--- a/skills/tl-create-workflow/references/pitfalls.md
+++ b/skills/tl-create-workflow/references/pitfalls.md
@@ -1,0 +1,68 @@
+# Pitfalls — the failure modes hand-built workflows hit
+
+These come from real workflows the team built (and abandoned). Design around
+them from the start; most of a good workflow is just not stepping on these.
+
+## 1. A query where a list belongs (the big one)
+
+Making stage 2+ a **query** instead of a **list** is the #1 breakage. A query
+recomputes its members from the index every time — it has nothing to *hold* the
+entities you move into it, so "moved" channels vanish on the next load. **Only
+the entry stage is a query; everything after it is a list.** If the user wants
+to "filter" a mid-funnel stage, that's a transient **view filter** on the
+list's rows (narrow what's shown so you can bulk-select), not a query stage.
+
+## 2. Empty pipeline
+
+Delivering a funnel whose entry stage is empty (or filled with placeholder
+channels) is a non-deliverable. The entry stage must be **sourced from real
+index data** — `tl-keyword-research`, `tl channels`, `tl recommender`,
+guide-brand look-alikes — with its breadth sense-checked against the goal.
+
+## 3. Over-nesting linked reports
+
+A stage can include/exclude other reports, which can themselves include others.
+There's **no depth limit in the platform**, and deep/wide nests resolve
+exponentially (slow) and become impossible to reason about ("this report
+excludes that one, which includes this other one…"). **Cap it at 1–2 layers.**
+Prefer a flat stage with its own filters over a clever nest. Historically people
+added manual exclude-hacks to make a nested workflow usable — that's a smell,
+not a pattern to copy.
+
+## 4. Meaningless / churning stage names
+
+Stages are reports; their names are the report titles and they **persist** on
+the campaign (a real historical bug reverted them, now fixed). Pick names the
+team already uses for its process ("Get face on screen", "Reach out",
+"Contacted") — not generic CRM labels. Fewer meaningful stages beat many empty
+ones nobody works.
+
+## 5. Designing for one person on a shared object
+
+A workflow is **shared** across the team by default. Don't design it around one
+AM's private view; design the stages so several people can work them. (The
+platform's own per-user view feature is what lets each person hide the reports
+that aren't theirs — not something you configure here, but keep the shared
+reality in mind when naming/structuring stages.)
+
+## 6. Claiming you created it
+
+The CLI can't create the Workflow object — you **design, source, and
+blueprint**, and the user assembles it in the app (Convert → Add stage → …).
+Never say "I created your workflow." Say "here's your populated blueprint and
+the steps to stand it up."
+
+## 7. Too many stages
+
+A funnel with eight stages the team won't actually move channels through is
+worse than four they will. Map stages to the team's *real* process steps and
+stop where the process stops. Every stage is a report someone has to maintain.
+
+## Quick checklist
+
+- [ ] Entry stage is a **query**, populated from real data, breadth confirmed.
+- [ ] Every later stage is a **list**.
+- [ ] Nesting ≤ 1–2 layers; flat preferred.
+- [ ] Stage names are the team's real process words.
+- [ ] Per-stage columns the team acts on are noted.
+- [ ] You blueprinted + handed off assembly — you didn't claim to have created it.

--- a/skills/tl-create-workflow/references/workflow-model.md
+++ b/skills/tl-create-workflow/references/workflow-model.md
@@ -1,0 +1,89 @@
+# The Workflow data model — read this before designing anything
+
+A Workflow looks like a bespoke pipeline object. It isn't. It's a thin wrapper
+over the same **Report** (campaign) objects the platform already has. Get this
+model right and the rest of the skill is easy; get it wrong and you'll design
+workflows that break the way hand-built ones do.
+
+## A stage IS a Report
+
+- A **Workflow** has a `name`, a `report_type` (channels / brands / uploads /
+  sponsorships), an `owner`, and an ordered set of **steps**.
+- **There is no separate "step" / "stage" object.** A step *is* a `Campaign`
+  (the platform's word for a saved Report), linked to the workflow by a
+  `workflow` FK + a `workflow_step_number` that gives the order.
+- So "add a stage" = "create a report and hang it on the workflow at position
+  N". "Rename a stage" = "rename that report". Everything you know about
+  reports applies to stages.
+- A workflow is **typed**: every stage is the same `report_type`. You can't mix
+  channels and brands in one workflow.
+
+## Query vs list — the distinction that matters most
+
+Every report (stage) has a **FilterSet**. Whether a stage behaves as a **query**
+or a **list** is *not a stored flag* — it's implied by what's in that FilterSet:
+
+- **QUERY stage** — the FilterSet holds **filter criteria**: keywords, date
+  ranges, view/subscriber ranges, categories, content filters. The stage
+  *computes* its members by matching the index. It's a live search.
+- **LIST stage** — the FilterSet holds **explicit included / excluded
+  entities**: specific channels (or brands) that were put there. The stage *is*
+  that set. It doesn't search; it holds.
+
+Why it matters for building a workflow:
+
+- **The entry stage should be a QUERY.** It's the pool — the funnel needs a way
+  to *find* candidates, and a query does that (e.g. "channels matching this
+  topic / these guide-brand look-alikes").
+- **Every stage after the entry should be a LIST.** Downstream stages are where
+  you *move* entities into as they progress. Moving an entity = adding it to the
+  target stage's included list. A downstream stage that's a query has nothing to
+  hold what you move into it.
+- A query as anything but the first stage is the classic broken-workflow bug.
+  If a user asks for a mid-funnel "query" stage, what they usually want is a
+  **filter applied to a list stage's view** (narrow the visible rows) — that's a
+  transient view filter, not a query stage. Keep the stage a list.
+
+## Moving entities through the funnel
+
+- Users advance entities by **bulk-selecting** rows in a stage and clicking
+  **Move** (to the next stage) — this adds them to the target stage's included
+  list.
+- **Exclude / Remove** puts selected entities on a stage's *exclude* list
+  (removes them from that stage's results).
+- Moving and excluding are **non-destructive** to the rest of the stage — they
+  add to include/exclude lists, they don't rewrite the whole set. (This was a
+  real data-loss bug historically; it's fixed, but design as if every move is a
+  targeted add, because that's what it is.)
+
+## Linked reports (nesting) — powerful, easy to overuse
+
+- A stage can **include or exclude another report's entities** (not just
+  individual channels). E.g. a "Reach out" stage that *excludes* a "No email /
+  captcha" report so those channels never appear.
+- This nests: report A includes report B, which includes report C… There is **no
+  hard depth limit in the platform**, and deep chains are a documented
+  performance + comprehension trap (exponential resolution on wide/deep nests).
+- **Design rule: ≤1–2 layers of nesting.** Prefer a flat stage with its own
+  filters over a clever multi-level include/exclude chain. If you find yourself
+  drawing a nest more than two deep, flatten it.
+
+## Columns are per-stage
+
+- Each stage (report) has its own **columns**. A "Get face on screen" stage
+  wants a *Face On Screen* column; a "Reach out" stage wants an *Outreach email*
+  column. Note the acted-on column for each stage in the blueprint — the team
+  works off it.
+
+## Multi-user
+
+- A workflow is **shared** across the team by default — several account managers
+  work the same stages. (Per-user saved views — each person hiding the reports
+  that aren't theirs — is a platform feature area, not something you configure
+  from this skill.)
+
+## One-line summary to tell a user
+
+> A workflow is an ordered set of reports. The first one is a *search* (a query)
+> that finds your pool; each one after it is a *list* that you move channels
+> into as they move through the funnel.

--- a/skills/tl-create-workflow/references/workflow-model.md
+++ b/skills/tl-create-workflow/references/workflow-model.md
@@ -7,7 +7,7 @@ workflows that break the way hand-built ones do.
 
 ## A stage IS a Report
 
-- A **Workflow** has a `name`, a `report_type` (channels / brands / uploads /
+- A **Workflow** has a `name`, a `report_type` (content / brands / channels /
   sponsorships), an `owner`, and an ordered set of **steps**.
 - **There is no separate "step" / "stage" object.** A step *is* a `Campaign`
   (the platform's word for a saved Report), linked to the workflow by a

--- a/src/tl_cli/commands/workflows.py
+++ b/src/tl_cli/commands/workflows.py
@@ -106,6 +106,9 @@ def create_workflow(
     if not isinstance(steps, list) or not steps:
         err.print("[red]Blueprint needs a non-empty 'steps' list.[/red]")
         raise typer.Exit(1)
+    if not all(isinstance(step, dict) for step in steps):
+        err.print("[red]Each step in 'steps' must be a JSON object, e.g. {\"title\": \"Sourced\"}.[/red]")
+        raise typer.Exit(1)
 
     payload = {"name": wf_name, "report_type": rt, "steps": steps}
 

--- a/src/tl_cli/commands/workflows.py
+++ b/src/tl_cli/commands/workflows.py
@@ -1,0 +1,156 @@
+"""tl workflow — create a workflow (a pipeline of report-stages) from a blueprint.
+
+A workflow is an ordered funnel of report-stages channels/brands move through
+(Sourced → Qualify → … → Sold). `tl workflow create` POSTs a blueprint —
+`{name, report_type, steps:[{title, include_report_ids, exclude_report_ids}]}` —
+to the Bearer endpoint `/api/cli/v1/workflows/build`, which builds the whole
+pipeline (stages + linked reports + exclude-earlier chaining) in one atomic call
+and returns the workflow. The result is identical to one built in the web app and
+shows up in its workflow list/detail immediately.
+
+This is the create step of the `tl-create-workflow` skill: design + source the
+entry report, then feed the blueprint here.
+"""
+
+import json
+
+import typer
+from tl_cli._typer_utils import AlphaSortedTyperGroup
+from pytoon import encode as toon_encode
+from rich.console import Console
+
+from tl_cli.client.errors import ApiError, handle_api_error
+from tl_cli.client.http import get_client
+from tl_cli.output.formatter import detect_format
+
+app = typer.Typer(cls=AlphaSortedTyperGroup, help="Workflows (create a pipeline of report-stages)")
+err = Console(stderr=True)
+
+REPORT_TYPE_LABELS = {1: "Content", 2: "Brands", 3: "Channels", 8: "Sponsorships"}
+
+
+@app.command("create")
+def create_workflow(
+    file: str | None = typer.Option(
+        None, "--file", "-f",
+        help="Path to a blueprint JSON file: {name, report_type, steps:[{title, include_report_ids, exclude_report_ids}]}",
+    ),
+    config_json: str | None = typer.Option(
+        None, "--config",
+        help="Blueprint as inline JSON (mutually exclusive with --file; prefer --file to avoid shell quoting).",
+    ),
+    name: str | None = typer.Option(None, "--name", "-n", help="Workflow name (supplies/overrides the blueprint's name)."),
+    report_type: int | None = typer.Option(
+        None, "--report-type", help="1 content · 2 brands · 3 channels · 8 sponsorships (overrides the blueprint)."
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+    json_output: bool = typer.Option(False, "--json", help="Raw JSON output."),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)."),
+) -> None:
+    """Create a workflow from a blueprint.
+
+    The blueprint is a name + report_type + an ordered list of stages, each
+    optionally linking Include/Exclude reports:
+
+        {
+          "name": "Q3 Creator Outreach",
+          "report_type": 3,
+          "steps": [
+            {"title": "Sourced",   "include_report_ids": [4021], "exclude_report_ids": []},
+            {"title": "Qualify",   "include_report_ids": [], "exclude_report_ids": []},
+            {"title": "Reach out", "include_report_ids": [], "exclude_report_ids": []}
+          ]
+        }
+
+    Only reports you may edit are linked (others are dropped); the workflow is
+    owned by you. The entry stage should link a saved *query* report (see the
+    tl-create-workflow skill); later stages start empty and fill by moving.
+
+    Examples:
+        tl workflow create --file blueprint.json
+        tl workflow create --file blueprint.json --yes
+        tl workflow create --config "$(cat blueprint.json)" -n "Q3 Outreach"
+    """
+    if (file is None) == (config_json is None):
+        err.print("[red]Provide exactly one of --file <path> or --config '<json>'.[/red]")
+        raise typer.Exit(2)
+
+    try:
+        if file is not None:
+            with open(file, encoding="utf-8") as fh:
+                raw = fh.read()
+        else:
+            raw = config_json or ""
+        blueprint = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as e:
+        err.print(f"[red]Could not read blueprint JSON: {e}[/red]")
+        raise typer.Exit(1)
+
+    if not isinstance(blueprint, dict):
+        err.print("[red]Blueprint must be a JSON object.[/red]")
+        raise typer.Exit(1)
+    if name is not None:
+        blueprint["name"] = name
+    if report_type is not None:
+        blueprint["report_type"] = report_type
+
+    wf_name = str(blueprint.get("name") or "").strip()
+    rt = blueprint.get("report_type")
+    steps = blueprint.get("steps")
+    if not wf_name:
+        err.print("[red]Blueprint needs a name (pass one in the JSON or with --name).[/red]")
+        raise typer.Exit(1)
+    if rt not in REPORT_TYPE_LABELS:
+        err.print("[red]report_type must be one of 1 (content), 2 (brands), 3 (channels), 8 (sponsorships).[/red]")
+        raise typer.Exit(1)
+    if not isinstance(steps, list) or not steps:
+        err.print("[red]Blueprint needs a non-empty 'steps' list.[/red]")
+        raise typer.Exit(1)
+
+    payload = {"name": wf_name, "report_type": rt, "steps": steps}
+
+    if not yes:
+        err.print(
+            f"\n[bold]About to create a workflow:[/bold]"
+            f"\n  Name:   {wf_name}"
+            f"\n  Type:   {REPORT_TYPE_LABELS[rt]} (report_type={rt})"
+            f"\n  Stages: {len(steps)}"
+        )
+        for i, step in enumerate(steps):
+            title = str((step or {}).get("title") or f"Step {i + 1}")
+            inc = len((step or {}).get("include_report_ids") or [])
+            exc = len((step or {}).get("exclude_report_ids") or [])
+            err.print(f"    {i + 1}. {title}  [dim]({inc} include, {exc} exclude reports)[/dim]")
+        if not typer.confirm("Create this workflow?", default=True):
+            err.print("[dim]Cancelled.[/dim]")
+            raise typer.Exit(0)
+
+    fmt = detect_format(json_output, False, False, toon_output)
+    client = get_client()
+    try:
+        data = client.post("/workflows/build", json_body=payload)
+    except ApiError as e:
+        handle_api_error(e)
+        return
+    finally:
+        client.close()
+
+    if fmt == "toon":
+        print(toon_encode(data))
+    elif fmt == "json":
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        results = data.get("results", [{}])
+        workflow = results[0] if results else {}
+        breadcrumbs = data.get("_breadcrumbs") or []
+        open_path = next((c.get("command") for c in breadcrumbs if c.get("hint") == "Open in app"), None)
+        err.print()
+        err.print("[green bold]Workflow created![/green bold]")
+        err.print(f"  ID:   {workflow.get('id', '?')}")
+        err.print(f"  Name: {workflow.get('name', wf_name)}")
+        err.print(f"  Stages: {len(workflow.get('steps', steps))}")
+        if open_path:
+            err.print(f"  Open in app: https://app.thoughtleaders.io{open_path}")
+        err.print(
+            "\n[dim]Work the funnel in the app: open a stage, filter, select, and Move to the next stage.[/dim]"
+        )

--- a/src/tl_cli/main.py
+++ b/src/tl_cli/main.py
@@ -30,6 +30,7 @@ from tl_cli.commands.describe import app as describe_app
 from tl_cli.commands.schema import app as schema_app
 from tl_cli.commands.doctor import app as doctor_app
 from tl_cli.commands.reports import app as reports_app
+from tl_cli.commands.workflows import app as workflows_app
 from tl_cli.commands.setup import app as setup_app
 from tl_cli.commands.snapshots import app as snapshots_app
 from tl_cli.commands.uploads import app as uploads_app
@@ -98,6 +99,7 @@ app.add_typer(profiles_app, name="profiles")
 app.add_typer(recommender_app, name="recommender")
 app.add_typer(snapshots_app, name="snapshots")
 app.add_typer(reports_app, name="reports")
+app.add_typer(workflows_app, name="workflow")
 # Direct command (not a sub-Typer) so `tl bulk-import <entity> --campaign <id>`
 # parses ENTITY as the positional and --campaign as a command option, instead
 # of Typer treating `--campaign` as a group-level flag that has to come first.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,79 @@
+"""Tests for `tl workflow create` blueprint validation.
+
+These cover the input-validation paths that exit before any HTTP call, so no
+client mocking is needed. The command is invoked through the top-level app
+(`tl workflow create ...`) — the real invocation path — because a single-command
+Typer collapses its lone command when invoked in isolation.
+"""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from tl_cli.main import app
+
+runner = CliRunner()
+
+
+class TestWorkflowCreateValidation:
+    def test_no_source_rejected(self) -> None:
+        result = runner.invoke(app, ["workflow", "create"])
+        assert result.exit_code == 2
+        assert "exactly one" in (result.stderr or result.output).lower()
+
+    def test_both_file_and_config_rejected(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "bp.json"
+        cfg.write_text('{"name": "X", "report_type": 3, "steps": [{}]}', encoding="utf-8")
+        result = runner.invoke(
+            app, ["workflow", "create", "--file", str(cfg), "--config", "{}"]
+        )
+        assert result.exit_code == 2
+        assert "exactly one" in (result.stderr or result.output).lower()
+
+    def test_invalid_json_rejected(self) -> None:
+        result = runner.invoke(app, ["workflow", "create", "--config", "{not json"])
+        assert result.exit_code == 1
+        assert "blueprint json" in (result.stderr or result.output).lower()
+
+    def test_non_object_blueprint_rejected(self) -> None:
+        result = runner.invoke(app, ["workflow", "create", "--config", "[1, 2, 3]"])
+        assert result.exit_code == 1
+        assert "json object" in (result.stderr or result.output).lower()
+
+    def test_missing_name_rejected(self) -> None:
+        result = runner.invoke(
+            app,
+            ["workflow", "create", "--config", '{"report_type": 3, "steps": [{"title": "S"}]}'],
+        )
+        assert result.exit_code == 1
+        assert "name" in (result.stderr or result.output).lower()
+
+    def test_bad_report_type_rejected(self) -> None:
+        result = runner.invoke(
+            app,
+            ["workflow", "create", "--config", '{"name": "X", "report_type": 5, "steps": [{"title": "S"}]}'],
+        )
+        assert result.exit_code == 1
+        assert "report_type" in (result.stderr or result.output).lower()
+
+    def test_empty_steps_rejected(self) -> None:
+        result = runner.invoke(
+            app,
+            ["workflow", "create", "--config", '{"name": "X", "report_type": 3, "steps": []}'],
+        )
+        assert result.exit_code == 1
+        assert "steps" in (result.stderr or result.output).lower()
+
+    def test_non_dict_steps_rejected_cleanly(self) -> None:
+        # A hand-written blueprint that lists stage names as bare strings instead
+        # of objects. This must fail loud with a clean message — not crash with an
+        # AttributeError in the confirmation preview (the interactive path, no
+        # --yes, is where the preview loop runs).
+        result = runner.invoke(
+            app,
+            ["workflow", "create", "--config", '{"name": "X", "report_type": 3, "steps": ["Sourced", "Qualify"]}'],
+            input="y\n",
+        )
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "json object" in (result.stderr or result.output).lower()


### PR DESCRIPTION
## What

A new CLI skill, **`tl-create-workflow`**, that turns a sponsorship / sourcing goal into a **populated Workflow blueprint** — an ordered funnel of report-stages channels move through (Sourced → Qualify → Get face on screen → Reach out → Contacted …), with the entry stage sourced from real index data and every stage typed correctly.

Layout mirrors the existing skills (`tl-keyword-research`, `tl-channel-authenticity`): `SKILL.md` + `references/`.

```
skills/tl-create-workflow/
├─ SKILL.md
└─ references/
   ├─ workflow-model.md     # stage = Report; query vs list; moving; nesting
   ├─ methodology.md        # guide brands → TRUE-renewal winners → look-alikes → value vs price
   ├─ creating-in-app.md    # Convert → Add stage assembly + /api/workflows endpoints
   └─ pitfalls.md           # the failure modes hand-built workflows hit
```

## How it works

It **designs the funnel → sources the entry stage → emits a create-ready blueprint → hands off the in-app assembly steps**. Key facts it encodes:

- **A stage IS a Report** (campaign) linked by `workflow_step_number` — no separate stage object.
- **The entry stage is a query; every later stage is a list.** This is the #1 cause of broken hand-built workflows.
- **Nesting of linked reports is kept shallow (≤1–2 layers).**
- Funnel design follows the ThoughtLeaders methodology; entry-stage sourcing **delegates** to `tl-keyword-research` / `tl channels` / `tl recommender`.

## Scope / honesty

The `tl` CLI has **no workflow command** and `/api/workflows` is session-auth (not the CLI's Bearer), so the skill **prepares** a workflow (design + sourced entry report + blueprint) and the user assembles it in the web app (Convert → Add stage). It never claims to have created the workflow. If a from-scratch multi-stage create endpoint is added later, the blueprint is already its exact input.

## Notes

- No scripts yet — the data work delegates to the `tl` CLI and sibling skills; scripts can be added later (e.g. a stage-report config emitter) without changing the SKILL.md contract.