### PR TITLE
Add "tl skill" commands for distributed skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,21 @@ The plugin ships several focused skills (installed by all the `tl setup *` comma
 - **`tl-views-guarantee`** — sizes a multi-video sponsorship buy for a channel, returning the video bundle size, views guarantee, and likelihood to hit.
 - **`tl-top-partnerships`** — brand-user performance report. Ranks a brand's sold sponsorships by live eCPM vs the sold-date projection, aggregates per channel, and delivers a two-tab Google Sheet ("By Deal" / "By Channel") via `gws`. Uses only public CLI commands (`tl whoami`, `tl sponsorships list`).
 
+## Distributed skills
+
+Beyond the bundled set above, an organization can be granted additional skills that aren't part of a CLI release — `tl skill` fetches and installs them on demand into the same directories `tl setup` uses (Claude Code's standalone skills directory, OpenCode's skills directory, and the directory shared by Gemini and Codex), so every supported agent picks them up automatically.
+
+```bash
+tl skill list                 # skills available to your organization, with installed/latest versions
+tl skill list --all           # full catalog (full-access accounts only)
+tl skill download my-skill    # fetch and install into every AI-agent skill directory
+tl skill download my-skill --force   # overwrite a directory tl doesn't already manage
+tl skill update                # refresh every downloaded skill to its latest version
+tl skill remove my-skill        # uninstall a downloaded skill
+```
+
+A directory `tl skill download` doesn't already manage (no prior `tl`-managed install there) is left alone unless `--force` is passed — it never overwrites a skill you installed some other way. `tl` warns once a day, on any command, when a downloaded skill has a newer version available. `tl setup` and self-update re-syncs also respect these directories: a downloaded skill is never rmtree'd or overwritten, even if its name collides with a bundled skill.
+
 ## Output Formats
 
 By default, output is a styled table in the terminal and JSON when piped.

--- a/src/tl_cli/client/http.py
+++ b/src/tl_cli/client/http.py
@@ -23,8 +23,8 @@ class TLClient:
             },
         )
 
-    def get(self, path: str, params: dict | None = None) -> dict:
-        return self._request("GET", path, params=params)
+    def get(self, path: str, params: dict | None = None, timeout: float | None = None) -> dict:
+        return self._request("GET", path, params=params, timeout=timeout)
 
     def post(self, path: str, json_body: dict | None = None) -> dict:
         return self._request("POST", path, json_body=json_body)
@@ -38,20 +38,24 @@ class TLClient:
         path: str,
         params: dict | None = None,
         json_body: dict | None = None,
+        timeout: float | None = None,
     ) -> dict:
         headers = self._auth_headers()
+        # Only overrides the client's default timeout when the caller asks
+        # for one — passing `timeout=None` through to httpx means "no
+        # timeout", not "use the default", so it's omitted entirely here.
+        request_kwargs = {"params": params, "json": json_body, "headers": headers}
+        if timeout is not None:
+            request_kwargs["timeout"] = timeout
 
-        response = self._client.request(
-            method, path, params=params, json=json_body, headers=headers
-        )
+        response = self._client.request(method, path, **request_kwargs)
 
         # On 401, try refreshing the token once
         if response.status_code == 401:
             headers = self._refresh_and_get_headers()
             if headers:
-                response = self._client.request(
-                    method, path, params=params, json=json_body, headers=headers
-                )
+                request_kwargs["headers"] = headers
+                response = self._client.request(method, path, **request_kwargs)
 
         if response.status_code >= 400:
             detail = self._extract_detail(response)

--- a/src/tl_cli/commands/setup.py
+++ b/src/tl_cli/commands/setup.py
@@ -21,6 +21,7 @@ from pytoon import encode as toon_encode
 from rich.console import Console
 
 from tl_cli import __version__
+from tl_cli.skill_registry import is_marked_for
 
 app = typer.Typer(cls=AlphaSortedTyperGroup, help="Set up integrations (Claude Code, OpenCode, Gemini, Codex)")
 console = Console(stderr=True)
@@ -201,6 +202,20 @@ def check_plugin_version() -> list[str]:
     return warnings
 
 
+def _warn_marker_skip(path: Path, name: str) -> None:
+    """Print the standard warning when setup leaves a tl-managed skill dir alone.
+
+    Shared by every place in this module that would otherwise rmtree/copytree
+    over a skill directory — a directory carrying a valid `.tl-skill.json`
+    marker was installed by `tl skill download` and must never be clobbered
+    by a bundled-skill sync, regardless of name collision or content match.
+    """
+    console.print(
+        f"  [yellow]![/yellow] skipping {path}: managed by 'tl skill' downloads — "
+        f"remove with [cyan]tl skill remove {name}[/cyan] if you want the bundled version"
+    )
+
+
 def _install_standalone_skills(plugin_root: Path) -> int:
     """Copy skills and commands to ~/.claude/ for non-namespaced invocation.
 
@@ -214,6 +229,9 @@ def _install_standalone_skills(plugin_root: Path) -> int:
         for skill_dir in skills_src.iterdir():
             if skill_dir.is_dir() and (skill_dir / "SKILL.md").is_file():
                 dst = CLAUDE_SKILLS_DIR / skill_dir.name
+                if dst.exists() and is_marked_for(dst, skill_dir.name):
+                    _warn_marker_skip(dst, skill_dir.name)
+                    continue
                 if dst.exists():
                     shutil.rmtree(dst)
                 shutil.copytree(skill_dir, dst)
@@ -278,6 +296,11 @@ def _remove_matching_standalone_skills(plugin_root: Path) -> tuple[int, int]:
             continue
         standalone = CLAUDE_SKILLS_DIR / skill_dir.name
         if not standalone.is_dir():
+            continue
+        if is_marked_for(standalone, skill_dir.name):
+            # tl-managed download — excluded from deletion candidates entirely,
+            # regardless of whether its content happens to match the bundled skill.
+            _warn_marker_skip(standalone, skill_dir.name)
             continue
         if _trees_identical(skill_dir, standalone):
             shutil.rmtree(standalone)
@@ -537,7 +560,10 @@ def _install_skill_trees(plugin_root: Path, target_dir: Path) -> int:
     (OpenCode, Gemini, Codex) — each agent reads skills from a different
     base directory, so we just parameterise on that. A `.tl-version`
     stamp is written into the target so `check_plugin_version()` can
-    detect drift later. Returns the number of skills installed.
+    detect drift later. A destination carrying a `.tl-skill.json` marker
+    for this skill name is a `tl skill download` install — it's skipped
+    (with a warning) rather than clobbered, and isn't counted in the
+    returned total. Returns the number of skills installed.
     """
     count = 0
     skills_src = plugin_root / "skills"
@@ -545,6 +571,9 @@ def _install_skill_trees(plugin_root: Path, target_dir: Path) -> int:
         for skill_dir in skills_src.iterdir():
             if skill_dir.is_dir() and (skill_dir / "SKILL.md").is_file():
                 dst = target_dir / skill_dir.name
+                if dst.exists() and is_marked_for(dst, skill_dir.name):
+                    _warn_marker_skip(dst, skill_dir.name)
+                    continue
                 if dst.exists():
                     shutil.rmtree(dst)
                 shutil.copytree(skill_dir, dst)

--- a/src/tl_cli/commands/skills.py
+++ b/src/tl_cli/commands/skills.py
@@ -1,0 +1,437 @@
+"""tl skill — Download, list, update, and remove server-distributed skills.
+
+Distinct from the bundled skill set `tl setup claude|opencode|gemini|codex`
+installs: these are skills an organization has been granted access to on
+the server, fetched and installed on demand.
+"""
+
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from tl_cli._typer_utils import AlphaSortedTyperGroup
+from tl_cli.client.errors import ApiError, handle_api_error
+from tl_cli.client.http import get_client
+from tl_cli.commands.setup import AGENTS_SKILLS_DIR, CLAUDE_SKILLS_DIR, OPENCODE_SKILLS_DIR
+from tl_cli.output.formatter import detect_format, output
+from tl_cli.skill_registry import (
+    InvalidSkillNameError,
+    PathSafetyError,
+    install_skill_tree,
+    is_marked_for,
+    read_registry,
+    read_staleness_cache,
+    validate_files,
+    validate_skill_name,
+    write_registry,
+    write_staleness_cache,
+    write_staleness_failure,
+)
+
+app = typer.Typer(cls=AlphaSortedTyperGroup, help="Download, list, update, and remove distributed skills")
+console = Console(stderr=True)
+
+COLUMNS = ["name", "latest_version", "installed_version", "status", "description"]
+
+# Kept well under the client's default 30s timeout: this call runs on every
+# `tl` invocation in the background, so a hung/slow server should fail fast
+# rather than stall the user's actual command for up to 30s.
+STALENESS_CHECK_TIMEOUT_SECONDS = 5.0
+
+
+def _install_targets() -> list[Path]:
+    """Every skill-directory root a downloaded skill installs into.
+
+    Mirrors the harness targets `tl setup` uses for the bundled skill set:
+    Claude Code's standalone skills directory (the plugin/marketplace
+    channel only ships the bundled set via GitHub releases and can't
+    deliver a single downloaded skill on its own), OpenCode's skills
+    directory, and the directory shared by Gemini and Codex. Reused
+    directly from `tl_cli.commands.setup` rather than duplicated here.
+    """
+    return [CLAUDE_SKILLS_DIR, OPENCODE_SKILLS_DIR, AGENTS_SKILLS_DIR]
+
+
+def _truncate(text: str, limit: int = 80) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _install_one(
+    dest: Path,
+    *,
+    name: str,
+    version: str,
+    checksum: str,
+    files: dict[str, str],
+    force: bool,
+) -> dict:
+    """Install a skill tree into a single target directory.
+
+    A destination that already exists and carries our marker for `name` is
+    always replaced. A destination that exists without our marker is
+    refused unless `force` is set.
+    """
+    if dest.exists() and not is_marked_for(dest, name):
+        if not force:
+            return {
+                "path": str(dest),
+                "installed": False,
+                "action": "refused",
+                "reason": "already exists and is not managed by tl (use --force to overwrite)",
+            }
+        action = "overwritten"
+    elif dest.exists():
+        action = "replaced"
+    else:
+        action = "installed"
+
+    install_skill_tree(files, dest, name=name, version=version, checksum=checksum)
+    return {"path": str(dest), "installed": True, "action": action}
+
+
+def _fetch_skill(name: str) -> dict:
+    """GET /skills/<name>/ and return its `results` block."""
+    client = get_client()
+    try:
+        data = client.get(f"/skills/{name}/")
+    finally:
+        client.close()
+    return data.get("results", data)
+
+
+def _download_and_install(name: str, *, force: bool) -> dict:
+    """Fetch a skill and install it to every target directory.
+
+    Shared by `tl skill download` and `tl skill update` — `update` always
+    passes `force=False`: a directory that already carries our marker for
+    this skill is replaced regardless of `force`, so the flag only matters
+    for a directory `tl` doesn't recognize as its own, which `update`
+    should never silently clobber.
+    """
+    validate_skill_name(name)
+    result = _fetch_skill(name)
+    version = result["version"]
+    checksum = result["checksum"]
+    files = result["files"]
+
+    validate_files(files)
+
+    targets: list[dict] = []
+    installed_count = 0
+    for target_root in _install_targets():
+        dest = target_root / name
+        outcome = _install_one(dest, name=name, version=version, checksum=checksum, files=files, force=force)
+        targets.append(outcome)
+        if outcome["installed"]:
+            installed_count += 1
+
+    if installed_count:
+        registry = read_registry()
+        registry.setdefault("skills", {})[name] = {
+            "version": version,
+            "checksum": checksum,
+            "paths": [t["path"] for t in targets if t["installed"]],
+            "installed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        write_registry(registry)
+
+    return {
+        "name": name,
+        "version": version,
+        "checksum": checksum,
+        "targets": targets,
+        "installed_count": installed_count,
+    }
+
+
+def check_skill_staleness() -> str | None:
+    """Per-run staleness nag for downloaded skills.
+
+    Entirely best-effort: any failure (empty registry, no auth, network
+    down, corrupt cache, server error) silently returns None — this must
+    never break or slow down normal CLI usage. Only hits the network when
+    the cache is empty or older than 24h; otherwise reuses the cached
+    result. A *failed* network call is itself cached for a short backoff
+    window (`STALENESS_FAILURE_TTL_SECONDS`) so an unreachable/slow server
+    doesn't force a retry — and its accompanying httpx timeout — on every
+    single `tl` invocation; a success later overwrites that stamp and
+    resumes the normal 24h cache. Returns at most one short line naming
+    every skill that has drifted from its latest available version, or
+    None when nothing has (or the check was skipped/failed).
+    """
+    try:
+        registry = read_registry()
+        installed = registry.get("skills", {})
+        if not installed:
+            return None
+
+        cache = read_staleness_cache()
+        if cache is not None:
+            if cache.get("failed"):
+                return None
+            results = cache["results"]
+        else:
+            client = get_client()
+            try:
+                names = ",".join(sorted(installed.keys()))
+                data = client.get("/skills/versions/", params={"names": names}, timeout=STALENESS_CHECK_TIMEOUT_SECONDS)
+            except Exception:
+                write_staleness_failure()
+                return None
+            finally:
+                client.close()
+            results = data.get("results", {})
+            write_staleness_cache(results)
+
+        outdated = sorted(name for name, info in installed.items() if results.get(name) and results.get(name) != info.get("version"))
+        if not outdated:
+            return None
+        return f"{len(outdated)} skill(s) outdated ({', '.join(outdated)}) — run `tl skill update`"
+    except Exception:
+        return None
+
+
+# --- Typer app -------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def skill(ctx: typer.Context) -> None:
+    """Download, list, update, and remove skills distributed to your organization."""
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(list_cmd, all_=False, json_output=False, csv_output=False, md_output=False, toon_output=False)
+
+
+@app.command("list")
+def list_cmd(
+    all_: bool = typer.Option(False, "--all", help="List the full catalog (full-access accounts only)"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    csv_output: bool = typer.Option(False, "--csv", help="CSV output"),
+    md_output: bool = typer.Option(False, "--md", help="Markdown output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """List skills available to your organization (free).
+
+    Examples:
+        tl skill list
+        tl skill list --all      # full catalog (full-access accounts only)
+    """
+    fmt = detect_format(json_output, csv_output, md_output, toon_output)
+    client = get_client()
+    try:
+        params = {"all": "1"} if all_ else None
+        data = client.get("/skills/", params=params)
+    except ApiError as e:
+        handle_api_error(e)
+        return
+    finally:
+        client.close()
+
+    registry = read_registry()
+    installed = registry.get("skills", {})
+
+    rows = []
+    for item in data.get("results", []):
+        name = item.get("name")
+        latest = item.get("version")
+        inst = installed.get(name)
+        installed_version = inst["version"] if inst else None
+        outdated = bool(inst and latest and installed_version != latest)
+        rows.append(
+            {
+                "name": name,
+                "latest_version": latest,
+                "installed_version": installed_version or "—",
+                "status": "outdated" if outdated else "",
+                "description": _truncate(item.get("description") or ""),
+            }
+        )
+
+    if not rows:
+        if fmt == "json":
+            print(json.dumps({"results": []}, indent=2))
+        else:
+            console.print("[dim]No skills available for your organization.[/dim]")
+        return
+
+    envelope = {
+        "results": rows,
+        "total": len(rows),
+        "usage": data.get("usage"),
+        "_breadcrumbs": data.get("_breadcrumbs", []),
+    }
+    output(envelope, fmt, columns=COLUMNS, title="Skills")
+
+
+@app.command("download")
+def download_cmd(
+    name: str = typer.Argument(..., help="Skill name"),
+    force: bool = typer.Option(False, "--force", help="Overwrite an existing directory that isn't tl-managed"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Download a skill and install it into every AI-agent skill directory on this machine.
+
+    Installs into Claude Code's standalone skills directory, OpenCode's
+    skills directory, and the directory shared by Gemini and Codex — the
+    same targets `tl setup` uses for the bundled skill set. A destination
+    that already exists and isn't tracked by a previous `tl skill download`
+    is refused unless --force is passed; a destination tl previously
+    installed is always replaced with the new version.
+
+    Examples:
+        tl skill download my-skill
+        tl skill download my-skill --force
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    try:
+        result = _download_and_install(name, force=force)
+    except InvalidSkillNameError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    except ApiError as e:
+        handle_api_error(e)
+        return
+    except PathSafetyError as e:
+        console.print(f"[red]Error:[/red] server response contains an unsafe path: {e}")
+        raise typer.Exit(1)
+
+    if fmt == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        for t in result["targets"]:
+            if t["installed"]:
+                console.print(f"  [green]✓[/green] {t['action']}: {t['path']}")
+            else:
+                console.print(f"  [red]✗[/red] {t['action']}: {t['path']} — {t['reason']}")
+        console.print()
+
+    if result["installed_count"] == 0:
+        console.print(f"[red]{name} was not installed to any location.[/red]")
+        raise typer.Exit(1)
+
+    if fmt != "json":
+        console.print(f"installed {name} v{result['version']} to {result['installed_count']} location(s)")
+
+
+@app.command("update")
+def update_cmd(
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Refresh every downloaded skill to its latest available version.
+
+    Skills no longer available to your organization are reported, not
+    deleted — remove them explicitly with `tl skill remove <name>`.
+
+    Examples:
+        tl skill update
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    registry = read_registry()
+    installed = registry.get("skills", {})
+    if not installed:
+        if fmt == "json":
+            print(json.dumps({"updated": [], "gone": [], "unchanged": [], "failed": []}, indent=2))
+        else:
+            console.print("[dim]No downloaded skills to update.[/dim]")
+        return
+
+    client = get_client()
+    try:
+        names = ",".join(sorted(installed.keys()))
+        data = client.get("/skills/versions/", params={"names": names})
+    except ApiError as e:
+        handle_api_error(e)
+        return
+    finally:
+        client.close()
+
+    latest_versions = data.get("results", {})
+    updated: list[str] = []
+    gone: list[str] = []
+    unchanged: list[str] = []
+    failed: list[dict] = []
+
+    for name in sorted(installed.keys()):
+        latest = latest_versions.get(name)
+        current = installed[name].get("version")
+        if not latest:
+            gone.append(name)
+            continue
+        if latest == current:
+            unchanged.append(name)
+            continue
+        try:
+            _download_and_install(name, force=False)
+            updated.append(name)
+        except (ApiError, PathSafetyError, InvalidSkillNameError) as e:
+            failed.append({"name": name, "error": str(e)})
+
+    if fmt == "json":
+        print(json.dumps({"updated": updated, "gone": gone, "unchanged": unchanged, "failed": failed}, indent=2))
+        return
+
+    if updated:
+        console.print(f"[green]Updated:[/green] {', '.join(updated)}")
+    if gone:
+        console.print(f"[yellow]No longer available to your organization:[/yellow] {', '.join(gone)}")
+        console.print("  Run [bold]tl skill remove <name>[/bold] to clean these up.")
+    if unchanged:
+        console.print(f"[dim]Already up to date: {', '.join(unchanged)}[/dim]")
+    if failed:
+        console.print(f"[red]Failed:[/red] {', '.join(f['name'] for f in failed)}")
+    if not (updated or gone or unchanged or failed):
+        console.print("[dim]Nothing to update.[/dim]")
+
+
+@app.command("remove")
+def remove_cmd(
+    name: str = typer.Argument(..., help="Skill name"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Remove a downloaded skill from every location tl installed it.
+
+    Only deletes a directory if it still carries the `.tl-skill.json`
+    marker for this skill — a directory that's been manually replaced is
+    left untouched and reported as skipped.
+
+    Examples:
+        tl skill remove my-skill
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    registry = read_registry()
+    installed = registry.get("skills", {})
+    entry = installed.get(name)
+    if entry is None:
+        console.print(f"[yellow]{name} is not in the local skill registry.[/yellow]")
+        raise typer.Exit(1)
+
+    removed: list[str] = []
+    skipped: list[str] = []
+    for path_str in entry.get("paths", []):
+        path = Path(path_str)
+        if is_marked_for(path, name):
+            shutil.rmtree(path)
+            removed.append(path_str)
+        else:
+            skipped.append(path_str)
+
+    del installed[name]
+    write_registry(registry)
+
+    if fmt == "json":
+        print(json.dumps({"name": name, "removed": removed, "skipped": skipped}, indent=2))
+        return
+
+    for p in removed:
+        console.print(f"  [green]✓[/green] removed: {p}")
+    for p in skipped:
+        console.print(f"  [yellow]![/yellow] skipped (not tl-managed anymore): {p}")
+    console.print(f"{name} removed from registry ({len(removed)} location(s) deleted)")

--- a/src/tl_cli/main.py
+++ b/src/tl_cli/main.py
@@ -31,6 +31,7 @@ from tl_cli.commands.schema import app as schema_app
 from tl_cli.commands.doctor import app as doctor_app
 from tl_cli.commands.reports import app as reports_app
 from tl_cli.commands.setup import app as setup_app
+from tl_cli.commands.skills import app as skills_app, check_skill_staleness
 from tl_cli.commands.snapshots import app as snapshots_app
 from tl_cli.commands.uploads import app as uploads_app
 from tl_cli.commands.whoami import app as whoami_app
@@ -81,10 +82,18 @@ def main(
         for warn in check_plugin_version():
             Console(stderr=True).print(f"[yellow]{warn}[/yellow]")
 
+    # Skip for `skill` invocations themselves — the staleness nag would be
+    # noise while the user is already running the command that fixes it.
+    if "skill" not in sys.argv:
+        warn = check_skill_staleness()
+        if warn:
+            Console(stderr=True).print(f"[yellow]{warn}[/yellow]")
+
 
 # System
 app.add_typer(auth_app, name="auth")
 app.add_typer(setup_app, name="setup")
+app.add_typer(skills_app, name="skill")
 
 # Data commands (primary interface)
 app.add_typer(sponsorships_app, name="sponsorships")

--- a/src/tl_cli/skill_registry.py
+++ b/src/tl_cli/skill_registry.py
@@ -22,6 +22,7 @@ of this change).
 """
 
 import json
+import ntpath
 import os
 import re
 import shutil
@@ -86,6 +87,11 @@ def validate_relpath(relpath: str) -> None:
         raise PathSafetyError(f"NUL byte not allowed in path: {relpath!r}")
     if relpath.startswith("/"):
         raise PathSafetyError(f"absolute path not allowed: {relpath!r}")
+    # A Windows drive-qualified path ('C:/x', 'C:x') is absolute on Windows, so
+    # joining it to the install directory would discard that directory. This is
+    # pure string logic and is correct regardless of the host OS.
+    if ntpath.splitdrive(relpath)[0]:
+        raise PathSafetyError(f"drive-qualified path not allowed: {relpath!r}")
     for segment in relpath.split("/"):
         if segment in ("", ".", ".."):
             raise PathSafetyError(f"unsafe path segment in {relpath!r}")

--- a/src/tl_cli/skill_registry.py
+++ b/src/tl_cli/skill_registry.py
@@ -1,0 +1,306 @@
+"""Local bookkeeping for downloaded skills: registry, install marker, path
+safety, and atomic install.
+
+Three files this module owns:
+
+- ``~/.config/tl/skills.json`` — the registry of every skill `tl skill
+  download` has installed, and where.
+- ``.tl-skill.json`` — written inside each installed skill directory so a
+  later run can tell "this directory is ours" apart from a user's own
+  skill of the same name. `tl setup` / `tl update`'s cleanup routines are
+  expected to import ``is_marked_for`` so they never touch a marker-bearing
+  directory (see module docstring note at the bottom).
+- ``~/.config/tl/skills-check.json`` — a 24h cache for the per-run
+  staleness check in ``tl_cli.commands.skills``.
+
+Kept separate from ``tl_cli/commands/skills.py`` (the Typer app) so the
+install/registry primitives have no dependency on the HTTP client or Typer —
+that keeps them trivially importable from `tl_cli/commands/setup.py` and
+`tl_cli/self_update.py`, whose cleanup routines need `is_marked_for` to skip
+directories `tl skill download` manages (tracked as follow-up work; not part
+of this change).
+"""
+
+import json
+import os
+import re
+import shutil
+import time
+import uuid
+from pathlib import Path
+
+from tl_cli.config import CONFIG_DIR
+
+REGISTRY_PATH = CONFIG_DIR / "skills.json"
+MARKER_FILENAME = ".tl-skill.json"
+STALENESS_CACHE_PATH = CONFIG_DIR / "skills-check.json"
+STALENESS_TTL_SECONDS = 24 * 3600
+# Backoff window after a *failed* staleness check (unreachable/slow server):
+# much shorter than the 24h success TTL, so the network gets retried again
+# reasonably soon, but not on literally every single `tl` invocation.
+STALENESS_FAILURE_TTL_SECONDS = 3600
+
+SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SKILL_NAME_MAX_LENGTH = 64
+
+
+class PathSafetyError(ValueError):
+    """A server-supplied relative file path failed safety validation."""
+
+
+class InvalidSkillNameError(ValueError):
+    """A user-typed skill name doesn't match the allowed name shape."""
+
+
+def validate_skill_name(name: str) -> None:
+    """Raise `InvalidSkillNameError` unless `name` is a safe skill identifier.
+
+    Checked before any network call or path construction: `download`/`update`
+    build `target_root / name` directly from this value, so a name shaped
+    like a path (e.g. containing `/`, `..`, or backslashes) must never reach
+    that join.
+    """
+    if not isinstance(name, str) or len(name) > SKILL_NAME_MAX_LENGTH or not SKILL_NAME_RE.match(name):
+        raise InvalidSkillNameError(
+            f"invalid skill name: {name!r} — expected lowercase letters, digits, and hyphens "
+            f"(starting with a letter or digit), {SKILL_NAME_MAX_LENGTH} characters or fewer"
+        )
+
+
+# --- Path safety -------------------------------------------------------
+
+
+def validate_relpath(relpath: str) -> None:
+    """Raise `PathSafetyError` unless `relpath` is a safe relative POSIX path.
+
+    Defense in depth: the server validates the same rules before a skill
+    bundle is ever stored, but a client-side check costs nothing and
+    protects against a compromised or buggy server response before a
+    single byte is written to disk.
+    """
+    if not isinstance(relpath, str) or not relpath:
+        raise PathSafetyError(f"empty or non-string file path: {relpath!r}")
+    if "\\" in relpath:
+        raise PathSafetyError(f"backslash not allowed in path: {relpath!r}")
+    if "\x00" in relpath:
+        raise PathSafetyError(f"NUL byte not allowed in path: {relpath!r}")
+    if relpath.startswith("/"):
+        raise PathSafetyError(f"absolute path not allowed: {relpath!r}")
+    for segment in relpath.split("/"):
+        if segment in ("", ".", ".."):
+            raise PathSafetyError(f"unsafe path segment in {relpath!r}")
+
+
+def validate_files(files: dict[str, str]) -> None:
+    """Validate every path in a `{relpath: content}` skill bundle upfront.
+
+    Called before any target directory is touched, so a single bad path
+    aborts the whole install rather than leaving some targets written and
+    others not.
+    """
+    for relpath, content in files.items():
+        validate_relpath(relpath)
+        if not isinstance(content, str):
+            raise PathSafetyError(f"file content for {relpath!r} must be text")
+
+
+def _resolve_within(target_dir: Path, relpath: str) -> Path:
+    """Resolve `relpath` under `target_dir`, asserting containment.
+
+    Second, independent check (path-resolution-based rather than
+    string-based) applied at write time as the ultimate safety net.
+    """
+    validate_relpath(relpath)
+    dest = (target_dir / relpath).resolve()
+    if not dest.is_relative_to(target_dir.resolve()):
+        raise PathSafetyError(f"path escapes target directory: {relpath!r}")
+    return dest
+
+
+# --- Marker --------------------------------------------------------------
+
+
+def read_marker(path: Path) -> dict | None:
+    """Read and validate `.tl-skill.json` in `path`. None if absent/invalid."""
+    marker_path = path / MARKER_FILENAME
+    try:
+        data = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if not all(isinstance(data.get(k), str) for k in ("name", "version", "checksum", "managed_by")):
+        return None
+    return data
+
+
+def is_marked_for(path: Path, name: str) -> bool:
+    """True if `path` is a directory carrying a valid tl-managed marker for `name`.
+
+    This is the safety predicate every mutation in this module (and, per
+    the module docstring, `tl setup` / `tl update`'s cleanup routines)
+    must check before touching an existing directory: unmarked dirs are
+    never assumed to be ours.
+    """
+    if not path.is_dir():
+        return False
+    marker = read_marker(path)
+    return marker is not None and marker.get("managed_by") == "tl" and marker.get("name") == name
+
+
+def write_marker(path: Path, *, name: str, version: str, checksum: str) -> None:
+    marker = {"name": name, "version": version, "checksum": checksum, "managed_by": "tl"}
+    (path / MARKER_FILENAME).write_text(json.dumps(marker), encoding="utf-8")
+
+
+# --- Atomic install --------------------------------------------------------
+
+
+def install_skill_tree(
+    files: dict[str, str],
+    target_dir: Path,
+    *,
+    name: str,
+    version: str,
+    checksum: str,
+) -> None:
+    """Atomically write `files` (relpath -> text) into `target_dir`.
+
+    Writes the whole tree to a sibling temp directory first (same
+    filesystem, so the final rename is atomic), adds the `.tl-skill.json`
+    marker, then swaps: any existing `target_dir` is moved aside, the temp
+    directory takes its place, and the old one is deleted. On any failure
+    the temp directory is cleaned up and `target_dir` is left exactly as
+    it was — nothing partially written.
+
+    Callers are expected to have already run `validate_files` on the whole
+    bundle; the per-file `_resolve_within` check here is a second,
+    independent safety net, not the primary gate.
+    """
+    parent = target_dir.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = parent / f".{name}.tmp-{uuid.uuid4().hex[:8]}"
+    try:
+        tmp_dir.mkdir(parents=True)
+        for relpath, content in files.items():
+            dest = _resolve_within(tmp_dir, relpath)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+        write_marker(tmp_dir, name=name, version=version, checksum=checksum)
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+    old_dir = parent / f".{name}.old-{uuid.uuid4().hex[:8]}"
+    moved_old = False
+    if target_dir.exists():
+        target_dir.rename(old_dir)
+        moved_old = True
+    try:
+        tmp_dir.rename(target_dir)
+    except Exception:
+        if moved_old:
+            old_dir.rename(target_dir)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+    if moved_old:
+        shutil.rmtree(old_dir, ignore_errors=True)
+
+
+# --- Atomic JSON write -----------------------------------------------------
+
+
+def _atomic_write_json(path: Path, data: dict, *, indent: int | None = None) -> None:
+    """Write `data` as JSON to `path` via a temp file + `os.replace`.
+
+    Serialization happens before any file is touched, so a bad `data` (e.g.
+    non-serializable content) raises without disturbing `path`. The payload
+    is then written to a sibling temp file and swapped in with `os.replace`
+    — atomic on the same filesystem — so a crash mid-write can never leave
+    `path` half-written; the previous content survives untouched until the
+    swap succeeds.
+    """
+    payload = json.dumps(data, indent=indent)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.parent / f".{path.name}.tmp-{uuid.uuid4().hex[:8]}"
+    try:
+        tmp_path.write_text(payload, encoding="utf-8")
+        os.replace(tmp_path, path)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+# --- Registry --------------------------------------------------------------
+
+
+def read_registry() -> dict:
+    """Read `skills.json`, tolerating a missing or corrupt file."""
+    try:
+        data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"skills": {}}
+    if not isinstance(data, dict) or not isinstance(data.get("skills"), dict):
+        return {"skills": {}}
+    return data
+
+
+def write_registry(data: dict) -> None:
+    _atomic_write_json(REGISTRY_PATH, data, indent=2)
+
+
+# --- Staleness cache ---------------------------------------------------
+
+
+def read_staleness_cache() -> dict | None:
+    """Return the cached `/skills/versions/` outcome, success or failure.
+
+    A successful check is cached for `STALENESS_TTL_SECONDS` (24h) and
+    returns the cached `results` dict. A *failed* check (network error,
+    unreachable/slow server) is cached for the much shorter
+    `STALENESS_FAILURE_TTL_SECONDS` backoff window and returned as
+    `{"checked_at": ..., "failed": True}` — callers must check `failed`
+    before touching `results`. Returns None once either window has
+    expired, or the file is missing/corrupt/malshaped.
+    """
+    try:
+        cache = json.loads(STALENESS_CACHE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(cache, dict):
+        return None
+    checked_at = cache.get("checked_at")
+    if not isinstance(checked_at, (int, float)):
+        return None
+
+    if cache.get("failed"):
+        if time.time() - checked_at >= STALENESS_FAILURE_TTL_SECONDS:
+            return None
+        return cache
+
+    if time.time() - checked_at >= STALENESS_TTL_SECONDS:
+        return None
+    if not isinstance(cache.get("results"), dict):
+        return None
+    return cache
+
+
+def write_staleness_cache(results: dict) -> None:
+    try:
+        _atomic_write_json(STALENESS_CACHE_PATH, {"checked_at": time.time(), "results": results})
+    except OSError:
+        pass
+
+
+def write_staleness_failure() -> None:
+    """Record a failed staleness check so the next run backs off the network.
+
+    Called instead of `write_staleness_cache` when the `/skills/versions/`
+    call itself fails — writing this stamp is what makes subsequent `tl`
+    invocations skip the network (and its timeout) for
+    `STALENESS_FAILURE_TTL_SECONDS`, instead of retrying on every run.
+    """
+    try:
+        _atomic_write_json(STALENESS_CACHE_PATH, {"checked_at": time.time(), "failed": True})
+    except OSError:
+        pass

--- a/tests/test_setup_marker_respect.py
+++ b/tests/test_setup_marker_respect.py
@@ -1,0 +1,214 @@
+"""Tests for setup.py's respect of `.tl-skill.json`-marked skill directories.
+
+Encodes the P9 rule: a directory downloaded via `tl skill download` must
+survive `tl setup` / `tl update` re-syncs untouched, even when its name
+collides with a bundled skill and even when its content happens to be
+byte-identical to the bundled version. Unmarked (or corrupt-marker) dirs
+keep the pre-existing behaviour — installed/refreshed or removed as before.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tl_cli.commands import setup
+from tl_cli.commands.setup import (
+    _install_skill_trees,
+    _install_standalone_skills,
+    _remove_matching_standalone_skills,
+)
+from tl_cli.skill_registry import install_skill_tree
+
+
+def _write_bundled_skill(plugin_root: Path, name: str, body: str) -> Path:
+    skill_dir = plugin_root / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    return skill_dir
+
+
+class TestInstallSkillTreesRespectsMarker:
+    def test_marked_dir_survives_and_sibling_still_installs(self, tmp_path, capsys):
+        plugin_root = tmp_path / "plugin"
+        _write_bundled_skill(plugin_root, "foo", "# bundled foo")
+        _write_bundled_skill(plugin_root, "bar", "# bundled bar")
+
+        target_dir = tmp_path / "agents" / "skills"
+        marked = target_dir / "foo"
+        install_skill_tree({"SKILL.md": "# downloaded foo"}, marked, name="foo", version="1.2.3", checksum="abc")
+        before = (marked / "SKILL.md").read_text(encoding="utf-8")
+
+        count = _install_skill_trees(plugin_root, target_dir)
+
+        # foo untouched (content + marker survive byte-for-byte); bar installed.
+        assert (marked / "SKILL.md").read_text(encoding="utf-8") == before
+        assert (marked / ".tl-skill.json").exists()
+        assert (target_dir / "bar" / "SKILL.md").read_text(encoding="utf-8") == "# bundled bar"
+        assert count == 1  # only bar counted — foo was skipped, not installed
+
+        err = capsys.readouterr().err.replace("\n", "")
+        assert "skipping" in err
+        assert str(marked) in err
+        assert "tl skill remove foo" in err
+
+    def test_unmarked_dir_still_replaced(self, tmp_path):
+        plugin_root = tmp_path / "plugin"
+        _write_bundled_skill(plugin_root, "foo", "# bundled foo")
+
+        target_dir = tmp_path / "agents" / "skills"
+        unmarked = target_dir / "foo"
+        unmarked.mkdir(parents=True)
+        (unmarked / "SKILL.md").write_text("old content", encoding="utf-8")
+
+        count = _install_skill_trees(plugin_root, target_dir)
+
+        assert count == 1
+        assert (unmarked / "SKILL.md").read_text(encoding="utf-8") == "# bundled foo"
+
+    def test_version_stamp_written_even_when_a_skill_is_skipped(self, tmp_path):
+        plugin_root = tmp_path / "plugin"
+        _write_bundled_skill(plugin_root, "foo", "# bundled foo")
+
+        target_dir = tmp_path / "agents" / "skills"
+        marked = target_dir / "foo"
+        install_skill_tree({"SKILL.md": "# downloaded"}, marked, name="foo", version="1.0.0", checksum="c")
+
+        _install_skill_trees(plugin_root, target_dir)
+
+        assert (target_dir / ".tl-version").read_text() == setup.__version__
+
+
+class TestInstallStandaloneSkillsRespectsMarker:
+    def test_marked_dir_survives_and_sibling_still_installs(self, tmp_path, monkeypatch, capsys):
+        plugin_root = tmp_path / "plugin"
+        _write_bundled_skill(plugin_root, "foo", "# bundled foo")
+        _write_bundled_skill(plugin_root, "bar", "# bundled bar")
+
+        claude_skills = tmp_path / "claude-skills"
+        monkeypatch.setattr(setup, "CLAUDE_SKILLS_DIR", claude_skills)
+
+        marked = claude_skills / "foo"
+        install_skill_tree({"SKILL.md": "# downloaded foo"}, marked, name="foo", version="1.2.3", checksum="abc")
+
+        count = _install_standalone_skills(plugin_root)
+
+        assert (marked / "SKILL.md").read_text(encoding="utf-8") == "# downloaded foo"
+        assert (claude_skills / "bar" / "SKILL.md").read_text(encoding="utf-8") == "# bundled bar"
+        assert count == 1  # bar only
+
+        err = capsys.readouterr().err.replace("\n", "")
+        assert "skipping" in err
+        assert "tl skill remove foo" in err
+
+
+class TestRemoveMatchingStandaloneSkillsRespectsMarker:
+    def test_marked_identical_copy_is_not_deleted(self, tmp_path, monkeypatch, capsys):
+        plugin_root = tmp_path / "plugin"
+        body = "---\nname: tl\n---\n"
+        _write_bundled_skill(plugin_root, "tl", body)
+
+        claude_skills = tmp_path / "claude-skills"
+        monkeypatch.setattr(setup, "CLAUDE_SKILLS_DIR", claude_skills)
+        marked = claude_skills / "tl"
+        # Byte-identical to the bundled skill, but tl-managed (marker present).
+        install_skill_tree({"SKILL.md": body}, marked, name="tl", version="1.0.0", checksum="c")
+
+        removed, kept = _remove_matching_standalone_skills(plugin_root)
+
+        assert removed == 0
+        assert kept == 0  # not "kept as modified" either — it's simply not a candidate
+        assert marked.exists()
+        assert (marked / ".tl-skill.json").exists()
+
+        err = capsys.readouterr().err.replace("\n", "")
+        assert "skipping" in err
+        assert "tl skill remove tl" in err
+
+    def test_unmarked_identical_copy_still_deleted(self, tmp_path, monkeypatch):
+        plugin_root = tmp_path / "plugin"
+        body = "---\nname: tl\n---\n"
+        _write_bundled_skill(plugin_root, "tl", body)
+
+        claude_skills = tmp_path / "claude-skills"
+        monkeypatch.setattr(setup, "CLAUDE_SKILLS_DIR", claude_skills)
+        copy = claude_skills / "tl"
+        copy.mkdir(parents=True)
+        (copy / "SKILL.md").write_text(body, encoding="utf-8")
+
+        removed, kept = _remove_matching_standalone_skills(plugin_root)
+
+        assert removed == 1
+        assert kept == 0
+        assert not copy.exists()
+
+
+class TestCorruptMarkerIsTreatedAsUnmanaged:
+    def test_corrupt_marker_file_does_not_block_install_skill_trees(self, tmp_path):
+        plugin_root = tmp_path / "plugin"
+        _write_bundled_skill(plugin_root, "foo", "# bundled foo")
+
+        target_dir = tmp_path / "agents" / "skills"
+        dest = target_dir / "foo"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text("old", encoding="utf-8")
+        (dest / ".tl-skill.json").write_text("{not json", encoding="utf-8")
+
+        count = _install_skill_trees(plugin_root, target_dir)
+
+        assert count == 1
+        assert (dest / "SKILL.md").read_text(encoding="utf-8") == "# bundled foo"
+
+    def test_corrupt_marker_file_falls_through_to_tree_comparison(self, tmp_path, monkeypatch, capsys):
+        """A corrupt `.tl-skill.json` is not a valid marker, so `is_marked_for`
+        is False and the directory is NOT excluded via the marker-skip path
+        (no warning printed) — it falls through to the pre-existing
+        byte-comparison logic instead. The stray marker file itself is an
+        extra file `_trees_identical` doesn't ignore, so the tree no longer
+        matches the bundled skill and the old code correctly keeps it
+        (as "modified"), rather than deleting or silently excluding it.
+        """
+        plugin_root = tmp_path / "plugin"
+        body = "---\nname: tl\n---\n"
+        _write_bundled_skill(plugin_root, "tl", body)
+
+        claude_skills = tmp_path / "claude-skills"
+        monkeypatch.setattr(setup, "CLAUDE_SKILLS_DIR", claude_skills)
+        copy = claude_skills / "tl"
+        copy.mkdir(parents=True)
+        (copy / "SKILL.md").write_text(body, encoding="utf-8")
+        (copy / ".tl-skill.json").write_text("{not json", encoding="utf-8")
+
+        removed, kept = _remove_matching_standalone_skills(plugin_root)
+
+        assert removed == 0
+        assert kept == 1  # old "modified copy" behavior, not the marker-skip path
+        assert copy.exists()
+        assert "skipping" not in capsys.readouterr().err
+
+
+class TestResyncIntegrationsHasNoDirectFileOps:
+    def test_resync_shells_out_to_tl_setup_only(self):
+        """`_resync_integrations` (self_update.py) re-syncs by spawning `tl setup
+        <tool> --json` subprocesses — it never touches skill directories itself,
+        so the marker-respect fix in setup.py's `_install_skill_trees` /
+        `_install_standalone_skills` covers it without any change needed here."""
+        import inspect
+
+        from tl_cli.self_update import _resync_integrations
+
+        src = inspect.getsource(_resync_integrations)
+        assert "rmtree" not in src
+        assert "copytree" not in src
+        assert "setup" in src  # confirms it delegates via `tl setup <tool>`
+
+
+@pytest.mark.parametrize("fn", [_install_skill_trees])
+def test_marker_skip_does_not_raise(tmp_path, fn):
+    """A skip must not raise or abort the loop — sanity guard against a
+    regression that would turn `continue` into an exception path."""
+    plugin_root = tmp_path / "plugin"
+    _write_bundled_skill(plugin_root, "foo", "# bundled foo")
+    target_dir = tmp_path / "target"
+    marked = target_dir / "foo"
+    install_skill_tree({"SKILL.md": "x"}, marked, name="foo", version="1.0.0", checksum="c")
+    fn(plugin_root, target_dir)  # must not raise

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -1,0 +1,373 @@
+"""Tests for `tl_cli.skill_registry`: path safety, atomic install, marker, registry.
+
+These encode the safety properties the plan calls out explicitly:
+a malicious or truncated server response cannot damage the client machine
+(path safety + atomic install), and routine registry reads survive a
+missing or corrupt file without crashing.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from tl_cli import skill_registry as sr
+
+# ---------------------------------------------------------------------------
+# Skill name validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSkillName:
+    @pytest.mark.parametrize("good", ["a", "foo", "foo-bar", "foo2", "a" * 64])
+    def test_accepts_valid_names(self, good):
+        sr.validate_skill_name(good)  # must not raise
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "-foo",
+            "Foo",
+            "foo/bar",
+            "foo\\bar",
+            "../evil",
+            "foo bar",
+            "foo_bar",
+            "a" * 65,
+        ],
+    )
+    def test_rejects_invalid_names(self, bad):
+        with pytest.raises(sr.InvalidSkillNameError):
+            sr.validate_skill_name(bad)
+
+
+# ---------------------------------------------------------------------------
+# Path safety
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRelpath:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "/etc/passwd",
+            "..\\evil",
+            "a\\b",
+            "../escape",
+            "a/../../escape",
+            "a/./b",
+            "a//b",
+            "a/",
+            "/a",
+            "a\x00b",
+        ],
+    )
+    def test_rejects_unsafe_paths(self, bad):
+        with pytest.raises(sr.PathSafetyError):
+            sr.validate_relpath(bad)
+
+    @pytest.mark.parametrize("good", ["SKILL.md", "scripts/run.py", "a/b/c.txt"])
+    def test_accepts_safe_paths(self, good):
+        sr.validate_relpath(good)  # must not raise
+
+
+class TestValidateFiles:
+    def test_rejects_traversal_in_bundle(self):
+        with pytest.raises(sr.PathSafetyError):
+            sr.validate_files({"SKILL.md": "ok", "../../etc/passwd": "evil"})
+
+    def test_rejects_absolute_path_in_bundle(self):
+        with pytest.raises(sr.PathSafetyError):
+            sr.validate_files({"SKILL.md": "ok", "/etc/passwd": "evil"})
+
+    def test_rejects_backslash_in_bundle(self):
+        with pytest.raises(sr.PathSafetyError):
+            sr.validate_files({"SKILL.md": "ok", "scripts\\evil.py": "x"})
+
+    def test_rejects_non_string_content(self):
+        with pytest.raises(sr.PathSafetyError):
+            sr.validate_files({"SKILL.md": 123})
+
+    def test_accepts_clean_bundle(self):
+        sr.validate_files({"SKILL.md": "ok", "scripts/run.py": "print()"})
+
+
+class TestInstallSkillTreePathSafety:
+    def test_traversal_path_aborts_install_nothing_written(self, tmp_path):
+        target = tmp_path / "install" / "myskill"
+        files = {"SKILL.md": "ok", "../escape.txt": "evil"}
+        with pytest.raises(sr.PathSafetyError):
+            sr.install_skill_tree(files, target, name="myskill", version="1.0.0", checksum="abc")
+        # Nothing was written: no target dir, no leftover temp/old siblings.
+        assert not target.exists()
+        leftovers = list(target.parent.iterdir()) if target.parent.exists() else []
+        assert leftovers == []
+
+    def test_absolute_path_aborts_install(self, tmp_path):
+        target = tmp_path / "install" / "myskill"
+        files = {"SKILL.md": "ok", "/etc/passwd": "evil"}
+        with pytest.raises(sr.PathSafetyError):
+            sr.install_skill_tree(files, target, name="myskill", version="1.0.0", checksum="abc")
+        assert not target.exists()
+
+    def test_backslash_path_aborts_install(self, tmp_path):
+        target = tmp_path / "install" / "myskill"
+        files = {"SKILL.md": "ok", "scripts\\evil.py": "x"}
+        with pytest.raises(sr.PathSafetyError):
+            sr.install_skill_tree(files, target, name="myskill", version="1.0.0", checksum="abc")
+        assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Atomic install
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicInstall:
+    def test_fresh_install_writes_files_and_marker(self, tmp_path):
+        target = tmp_path / "install" / "myskill"
+        files = {"SKILL.md": "# hello", "scripts/run.py": "print('hi')"}
+        sr.install_skill_tree(files, target, name="myskill", version="1.0.0", checksum="deadbeef")
+
+        assert (target / "SKILL.md").read_text() == "# hello"
+        assert (target / "scripts" / "run.py").read_text() == "print('hi')"
+        marker = json.loads((target / sr.MARKER_FILENAME).read_text())
+        assert marker == {
+            "name": "myskill",
+            "version": "1.0.0",
+            "checksum": "deadbeef",
+            "managed_by": "tl",
+        }
+        # No leftover temp/old siblings.
+        siblings = {p.name for p in target.parent.iterdir()}
+        assert siblings == {"myskill"}
+
+    def test_replaces_existing_marked_dir(self, tmp_path):
+        target = tmp_path / "install" / "myskill"
+        sr.install_skill_tree({"SKILL.md": "v1"}, target, name="myskill", version="1.0.0", checksum="c1")
+        sr.install_skill_tree({"SKILL.md": "v2"}, target, name="myskill", version="2.0.0", checksum="c2")
+
+        assert (target / "SKILL.md").read_text() == "v2"
+        marker = json.loads((target / sr.MARKER_FILENAME).read_text())
+        assert marker["version"] == "2.0.0"
+        siblings = {p.name for p in target.parent.iterdir()}
+        assert siblings == {"myskill"}  # old-* / tmp-* cleaned up
+
+    def test_mid_write_failure_leaves_previous_dir_intact(self, tmp_path):
+        target = tmp_path / "install" / "myskill"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text("original content", encoding="utf-8")
+        (target / sr.MARKER_FILENAME).write_text(
+            json.dumps({"name": "myskill", "version": "1.0.0", "checksum": "orig", "managed_by": "tl"}),
+            encoding="utf-8",
+        )
+
+        # "a" is written as a file; "a/sub.txt" then can't create its parent
+        # dir because "a" already exists as a regular file — a deterministic
+        # mid-loop failure with no monkeypatching required.
+        files = {"SKILL.md": "new content", "a": "file", "a/sub.txt": "nested"}
+        with pytest.raises(Exception):
+            sr.install_skill_tree(files, target, name="myskill", version="2.0.0", checksum="new")
+
+        # Previous directory is completely untouched.
+        assert (target / "SKILL.md").read_text(encoding="utf-8") == "original content"
+        marker = json.loads((target / sr.MARKER_FILENAME).read_text())
+        assert marker["version"] == "1.0.0"
+        # No leftover temp dirs.
+        siblings = {p.name for p in target.parent.iterdir()}
+        assert siblings == {"myskill"}
+
+    def test_creates_parent_directories(self, tmp_path):
+        target = tmp_path / "does" / "not" / "exist" / "myskill"
+        sr.install_skill_tree({"SKILL.md": "hi"}, target, name="myskill", version="1.0.0", checksum="c")
+        assert (target / "SKILL.md").read_text() == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Marker
+# ---------------------------------------------------------------------------
+
+
+class TestMarker:
+    def test_is_marked_for_true_for_matching_marker(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        sr.write_marker(d, name="foo", version="1.0.0", checksum="c")
+        assert sr.is_marked_for(d, "foo") is True
+
+    def test_is_marked_for_false_for_different_name(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        sr.write_marker(d, name="foo", version="1.0.0", checksum="c")
+        assert sr.is_marked_for(d, "bar") is False
+
+    def test_is_marked_for_false_when_no_marker(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        assert sr.is_marked_for(d, "foo") is False
+
+    def test_is_marked_for_false_when_marker_corrupt(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        (d / sr.MARKER_FILENAME).write_text("{not json", encoding="utf-8")
+        assert sr.is_marked_for(d, "foo") is False
+
+    def test_is_marked_for_false_when_marker_missing_keys(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        (d / sr.MARKER_FILENAME).write_text(json.dumps({"name": "foo"}), encoding="utf-8")
+        assert sr.is_marked_for(d, "foo") is False
+
+    def test_is_marked_for_false_when_not_a_directory(self, tmp_path):
+        f = tmp_path / "not-a-dir"
+        f.write_text("x", encoding="utf-8")
+        assert sr.is_marked_for(f, "foo") is False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_missing_file_returns_empty_registry(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sr, "REGISTRY_PATH", tmp_path / "skills.json")
+        assert sr.read_registry() == {"skills": {}}
+
+    def test_corrupt_file_returns_empty_registry(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills.json"
+        path.write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(sr, "REGISTRY_PATH", path)
+        assert sr.read_registry() == {"skills": {}}
+
+    def test_wrong_shape_returns_empty_registry(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills.json"
+        path.write_text(json.dumps({"skills": "not-a-dict"}), encoding="utf-8")
+        monkeypatch.setattr(sr, "REGISTRY_PATH", path)
+        assert sr.read_registry() == {"skills": {}}
+
+    def test_write_then_read_round_trips(self, tmp_path, monkeypatch):
+        path = tmp_path / "sub" / "skills.json"
+        monkeypatch.setattr(sr, "REGISTRY_PATH", path)
+        data = {"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "now"}}}
+        sr.write_registry(data)
+        assert sr.read_registry() == data
+
+
+# ---------------------------------------------------------------------------
+# Atomic write (N3): temp file + os.replace, crash-safe
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWrite:
+    def test_serialization_failure_leaves_existing_file_intact(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills.json"
+        monkeypatch.setattr(sr, "REGISTRY_PATH", path)
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        original = path.read_text(encoding="utf-8")
+
+        # A `set` isn't JSON-serializable — json.dumps raises before any
+        # file on disk is touched, so the previous content must survive.
+        bad_data = {"skills": {"foo": {"paths": {1, 2, 3}}}}
+        with pytest.raises(TypeError):
+            sr.write_registry(bad_data)
+
+        assert path.read_text(encoding="utf-8") == original
+        # No leftover temp file either.
+        assert [p.name for p in path.parent.iterdir()] == [path.name]
+
+    def test_write_uses_os_replace_and_cleans_up_temp_file(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills.json"
+        monkeypatch.setattr(sr, "REGISTRY_PATH", path)
+        calls = []
+        real_replace = sr.os.replace
+
+        def _spy_replace(src, dst):
+            calls.append(Path(src).name)
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(sr.os, "replace", _spy_replace)
+        sr.write_registry({"skills": {}})
+
+        assert len(calls) == 1
+        tmp_name = calls[0]
+        assert tmp_name != path.name  # written to a distinct temp file first
+        # After a successful swap, only the final file remains.
+        assert [p.name for p in path.parent.iterdir()] == [path.name]
+
+    def test_replace_failure_cleans_up_temp_file(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills.json"
+        monkeypatch.setattr(sr, "REGISTRY_PATH", path)
+
+        def _boom_replace(src, dst):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(sr.os, "replace", _boom_replace)
+        with pytest.raises(OSError):
+            sr.write_registry({"skills": {}})
+
+        # The failed swap must not leave the temp file behind, and the
+        # target was never created.
+        assert list(path.parent.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Staleness cache
+# ---------------------------------------------------------------------------
+
+
+class TestStalenessCache:
+    def test_missing_cache_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sr, "STALENESS_CACHE_PATH", tmp_path / "skills-check.json")
+        assert sr.read_staleness_cache() is None
+
+    def test_fresh_cache_returns_results(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills-check.json"
+        monkeypatch.setattr(sr, "STALENESS_CACHE_PATH", path)
+        sr.write_staleness_cache({"foo": "1.0.0"})
+        cache = sr.read_staleness_cache()
+        assert cache is not None
+        assert cache["results"] == {"foo": "1.0.0"}
+
+    def test_stale_cache_returns_none(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills-check.json"
+        path.write_text(
+            json.dumps({"checked_at": time.time() - sr.STALENESS_TTL_SECONDS - 1, "results": {"foo": "1.0.0"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sr, "STALENESS_CACHE_PATH", path)
+        assert sr.read_staleness_cache() is None
+
+    def test_corrupt_cache_returns_none(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills-check.json"
+        path.write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(sr, "STALENESS_CACHE_PATH", path)
+        assert sr.read_staleness_cache() is None
+
+    # -- W4: failure-stamp backoff --
+
+    def test_write_staleness_failure_then_read_within_window(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills-check.json"
+        monkeypatch.setattr(sr, "STALENESS_CACHE_PATH", path)
+        sr.write_staleness_failure()
+        cache = sr.read_staleness_cache()
+        assert cache is not None
+        assert cache["failed"] is True
+
+    def test_failure_stamp_expires_after_backoff_window(self, tmp_path, monkeypatch):
+        path = tmp_path / "skills-check.json"
+        path.write_text(
+            json.dumps({"checked_at": time.time() - sr.STALENESS_FAILURE_TTL_SECONDS - 1, "failed": True}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sr, "STALENESS_CACHE_PATH", path)
+        assert sr.read_staleness_cache() is None
+
+    def test_failure_stamp_backoff_is_shorter_than_success_ttl(self):
+        # The whole point of the failure stamp: back off for less time than
+        # a successful check is trusted for, so the network gets retried
+        # again reasonably soon rather than waiting a full day.
+        assert sr.STALENESS_FAILURE_TTL_SECONDS < sr.STALENESS_TTL_SECONDS

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -63,6 +63,9 @@ class TestValidateRelpath:
             "a/",
             "/a",
             "a\x00b",
+            "C:/Windows/System32/evil",
+            "C:evil",
+            "c:/evil",
         ],
     )
     def test_rejects_unsafe_paths(self, bad):

--- a/tests/test_skills_command.py
+++ b/tests/test_skills_command.py
@@ -1,0 +1,420 @@
+"""Tests for `tl skill list|download|update|remove` and the per-run
+staleness check, with the HTTP client mocked (no network) and every
+filesystem path redirected under tmp_path.
+
+Encodes: download refuses/overwrites/replaces per the marker rule; a path
+traversal in the server response aborts the whole install; update reports
+"gone" skills without deleting them; remove only deletes marker-bearing
+dirs; the staleness check makes at most one network call per day and is
+silent on any failure.
+"""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from tl_cli import skill_registry as sr
+from tl_cli.commands import skills as skills_mod
+from tl_cli.commands.skills import app as skills_app
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    """Routes `.get(path)` to a fixed per-path response; records calls."""
+
+    def __init__(self, responses: dict[str, dict]):
+        self.responses = responses
+        self.calls: list[tuple[str, dict]] = []
+        self.timeouts: list[float | None] = []
+
+    def get(self, path: str, params: dict | None = None, timeout: float | None = None) -> dict:
+        self.calls.append((path, params or {}))
+        self.timeouts.append(timeout)
+        if path not in self.responses:
+            raise AssertionError(f"unexpected call to {path!r} (params={params})")
+        return self.responses[path]
+
+    def close(self) -> None:
+        pass
+
+
+def _skill_payload(name: str, version: str, checksum: str, files: dict[str, str], **extra) -> dict:
+    return {"results": {"name": name, "version": version, "checksum": checksum, "files": files, "description": "", "changelog": "", **extra}}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_paths(tmp_path, monkeypatch):
+    """Redirect every install target + registry + cache under tmp_path."""
+    monkeypatch.setattr(skills_mod, "CLAUDE_SKILLS_DIR", tmp_path / "claude" / "skills")
+    monkeypatch.setattr(skills_mod, "OPENCODE_SKILLS_DIR", tmp_path / "opencode" / "skills")
+    monkeypatch.setattr(skills_mod, "AGENTS_SKILLS_DIR", tmp_path / "agents" / "skills")
+    monkeypatch.setattr(sr, "REGISTRY_PATH", tmp_path / "config" / "skills.json")
+    monkeypatch.setattr(sr, "STALENESS_CACHE_PATH", tmp_path / "config" / "skills-check.json")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# download
+# ---------------------------------------------------------------------------
+
+
+class TestDownload:
+    def test_fresh_install_to_all_three_targets(self, tmp_path):
+        fake = _FakeClient({"/skills/foo/": _skill_payload("foo", "1.0.0", "c1", {"SKILL.md": "# foo"})})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["download", "foo", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["installed_count"] == 3
+        for t in data["targets"]:
+            assert t["installed"] is True
+            assert t["action"] == "installed"
+            assert (Path(t["path"]) / "SKILL.md").read_text() == "# foo"
+
+        registry = sr.read_registry()
+        assert registry["skills"]["foo"]["version"] == "1.0.0"
+        assert len(registry["skills"]["foo"]["paths"]) == 3
+
+    def test_refuses_unmarked_existing_dir_without_force(self, tmp_path):
+        claude_dest = tmp_path / "claude" / "skills" / "foo"
+        claude_dest.mkdir(parents=True)
+        (claude_dest / "mine.txt").write_text("user's own content", encoding="utf-8")
+
+        fake = _FakeClient({"/skills/foo/": _skill_payload("foo", "1.0.0", "c1", {"SKILL.md": "# foo"})})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["download", "foo", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["installed_count"] == 2
+
+        refused = [t for t in data["targets"] if not t["installed"]]
+        assert len(refused) == 1
+        assert refused[0]["action"] == "refused"
+        # Untouched — the user's own file is still there.
+        assert (claude_dest / "mine.txt").read_text() == "user's own content"
+        assert not (claude_dest / "SKILL.md").exists()
+
+    def test_force_overwrites_unmarked_dir(self, tmp_path):
+        claude_dest = tmp_path / "claude" / "skills" / "foo"
+        claude_dest.mkdir(parents=True)
+        (claude_dest / "mine.txt").write_text("user's own content", encoding="utf-8")
+
+        fake = _FakeClient({"/skills/foo/": _skill_payload("foo", "1.0.0", "c1", {"SKILL.md": "# foo"})})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["download", "foo", "--force", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["installed_count"] == 3
+        assert (claude_dest / "SKILL.md").read_text() == "# foo"
+        assert not (claude_dest / "mine.txt").exists()
+
+    def test_replaces_marker_bearing_dir_without_force(self, tmp_path):
+        claude_dest = tmp_path / "claude" / "skills" / "foo"
+        sr.install_skill_tree({"SKILL.md": "old"}, claude_dest, name="foo", version="0.9.0", checksum="old")
+
+        fake = _FakeClient({"/skills/foo/": _skill_payload("foo", "1.0.0", "c1", {"SKILL.md": "new"})})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["download", "foo", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["installed_count"] == 3
+        claude_target = next(t for t in data["targets"] if "claude" in t["path"])
+        assert claude_target["action"] == "replaced"
+        assert (claude_dest / "SKILL.md").read_text() == "new"
+
+    def test_path_traversal_in_response_aborts_and_writes_nothing(self, tmp_path):
+        fake = _FakeClient({"/skills/foo/": _skill_payload("foo", "1.0.0", "c1", {"SKILL.md": "ok", "../evil.txt": "bad"})})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["download", "foo", "--json"])
+        assert result.exit_code != 0
+        for base in ("claude", "opencode", "agents"):
+            assert not (tmp_path / base / "skills" / "foo").exists()
+        assert sr.read_registry() == {"skills": {}}
+
+    def test_all_targets_refused_exits_nonzero(self, tmp_path):
+        for base in ("claude", "opencode", "agents"):
+            d = tmp_path / base / "skills" / "foo"
+            d.mkdir(parents=True)
+            (d / "mine.txt").write_text("mine", encoding="utf-8")
+
+        fake = _FakeClient({"/skills/foo/": _skill_payload("foo", "1.0.0", "c1", {"SKILL.md": "new"})})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["download", "foo", "--json"])
+        assert result.exit_code == 1
+        assert sr.read_registry() == {"skills": {}}
+
+
+# ---------------------------------------------------------------------------
+# download — invalid name rejected client-side (N2)
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadInvalidName:
+    @pytest.mark.parametrize("bad_name", ["../evil", "Foo", "foo/bar", "foo bar", "foo_bar", "a" * 65])
+    def test_invalid_name_rejected_before_any_network_call(self, tmp_path, bad_name):
+        mock_get_client = MagicMock()
+        with patch.object(skills_mod, "get_client", mock_get_client):
+            result = runner.invoke(skills_app, ["download", bad_name, "--json"])
+        assert result.exit_code != 0
+        assert not mock_get_client.called
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_merges_registry_and_marks_outdated(self, tmp_path):
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        fake = _FakeClient(
+            {"/skills/": {"results": [{"name": "foo", "version": "2.0.0", "description": "desc", "changelog": "", "updated_at": "x"}]}}
+        )
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["list", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        row = data["results"][0]
+        assert row["name"] == "foo"
+        assert row["latest_version"] == "2.0.0"
+        assert row["installed_version"] == "1.0.0"
+        assert row["status"] == "outdated"
+
+    def test_not_installed_shows_dash(self, tmp_path):
+        fake = _FakeClient({"/skills/": {"results": [{"name": "bar", "version": "1.0.0", "description": ""}]}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["list", "--json"])
+        assert result.exit_code == 0, result.output
+        row = json.loads(result.stdout)["results"][0]
+        assert row["installed_version"] == "—"
+        assert row["status"] == ""
+
+    def test_all_flag_sends_query_param(self, tmp_path):
+        fake = _FakeClient({"/skills/": {"results": []}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            runner.invoke(skills_app, ["list", "--all", "--json"])
+        assert fake.calls == [("/skills/", {"all": "1"})]
+
+    def test_empty_state_friendly_message(self, tmp_path):
+        # Force a non-JSON format explicitly — CliRunner's stdout isn't a
+        # tty, so `detect_format` would otherwise default to "json" here.
+        fake = _FakeClient({"/skills/": {"results": []}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["list", "--md"])
+        assert result.exit_code == 0, result.output
+        assert "No skills available for your organization" in (result.stderr or result.output)
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+class TestUpdate:
+    def test_empty_registry_is_a_friendly_no_op(self, tmp_path):
+        result = runner.invoke(skills_app, ["update", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data == {"updated": [], "gone": [], "unchanged": [], "failed": []}
+
+    def test_reports_gone_without_deleting(self, tmp_path):
+        dest = tmp_path / "claude" / "skills" / "foo"
+        sr.install_skill_tree({"SKILL.md": "x"}, dest, name="foo", version="1.0.0", checksum="c")
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [str(dest)], "installed_at": "x"}}})
+        fake = _FakeClient({"/skills/versions/": {"results": {"foo": None}}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["update", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["gone"] == ["foo"]
+        # Not deleted — files and registry entry both survive.
+        assert dest.exists()
+        assert "foo" in sr.read_registry()["skills"]
+
+    def test_reinstalls_newer_version(self, tmp_path):
+        dest = tmp_path / "claude" / "skills" / "foo"
+        sr.install_skill_tree({"SKILL.md": "old"}, dest, name="foo", version="1.0.0", checksum="c1")
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c1", "paths": [str(dest)], "installed_at": "x"}}})
+        fake = _FakeClient(
+            {
+                "/skills/versions/": {"results": {"foo": "2.0.0"}},
+                "/skills/foo/": _skill_payload("foo", "2.0.0", "c2", {"SKILL.md": "new"}),
+            }
+        )
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["update", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["updated"] == ["foo"]
+        assert (dest / "SKILL.md").read_text() == "new"
+        assert sr.read_registry()["skills"]["foo"]["version"] == "2.0.0"
+
+    def test_skips_unchanged(self, tmp_path):
+        dest = tmp_path / "claude" / "skills" / "foo"
+        sr.install_skill_tree({"SKILL.md": "same"}, dest, name="foo", version="1.0.0", checksum="c1")
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c1", "paths": [str(dest)], "installed_at": "x"}}})
+        fake = _FakeClient({"/skills/versions/": {"results": {"foo": "1.0.0"}}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            result = runner.invoke(skills_app, ["update", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["unchanged"] == ["foo"]
+        # No fetch of /skills/foo/ should have happened.
+        assert all(path != "/skills/foo/" for path, _ in fake.calls)
+
+
+# ---------------------------------------------------------------------------
+# remove
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    def test_deletes_only_marked_dirs(self, tmp_path):
+        marked = tmp_path / "claude" / "skills" / "foo"
+        sr.install_skill_tree({"SKILL.md": "x"}, marked, name="foo", version="1.0.0", checksum="c")
+
+        unmarked = tmp_path / "opencode" / "skills" / "foo"
+        unmarked.mkdir(parents=True)
+        (unmarked / "someone-elses.txt").write_text("not ours", encoding="utf-8")
+
+        sr.write_registry(
+            {
+                "skills": {
+                    "foo": {
+                        "version": "1.0.0",
+                        "checksum": "c",
+                        "paths": [str(marked), str(unmarked)],
+                        "installed_at": "x",
+                    }
+                }
+            }
+        )
+
+        result = runner.invoke(skills_app, ["remove", "foo", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["removed"] == [str(marked)]
+        assert data["skipped"] == [str(unmarked)]
+        assert not marked.exists()
+        assert unmarked.exists()  # left untouched
+        assert "foo" not in sr.read_registry()["skills"]
+
+    def test_unknown_skill_is_an_error(self, tmp_path):
+        result = runner.invoke(skills_app, ["remove", "nope", "--json"])
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# staleness check
+# ---------------------------------------------------------------------------
+
+
+class TestStalenessCheck:
+    def test_empty_registry_no_network_call(self, tmp_path):
+        mock_get_client = MagicMock()
+        with patch.object(skills_mod, "get_client", mock_get_client):
+            assert skills_mod.check_skill_staleness() is None
+        assert not mock_get_client.called
+
+    def test_fresh_cache_skips_network_call(self, tmp_path):
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        sr.write_staleness_cache({"foo": "1.0.0"})  # unchanged, and fresh
+
+        mock_get_client = MagicMock()
+        with patch.object(skills_mod, "get_client", mock_get_client):
+            warn = skills_mod.check_skill_staleness()
+        assert warn is None
+        assert not mock_get_client.called
+
+    def test_stale_cache_makes_one_call_and_warns_on_drift(self, tmp_path):
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        # No cache file at all == "stale" (treated as absent).
+        fake = _FakeClient({"/skills/versions/": {"results": {"foo": "2.0.0"}}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            warn = skills_mod.check_skill_staleness()
+        assert warn is not None
+        assert "foo" in warn
+        assert "tl skill update" in warn
+        assert len(fake.calls) == 1
+        # Result got cached for next time.
+        assert sr.read_staleness_cache()["results"] == {"foo": "2.0.0"}
+
+    def test_any_exception_is_silent(self, tmp_path, monkeypatch):
+        def _boom():
+            raise RuntimeError("registry is on fire")
+
+        monkeypatch.setattr(skills_mod, "read_registry", _boom)
+        assert skills_mod.check_skill_staleness() is None
+
+
+# ---------------------------------------------------------------------------
+# staleness check — failure backoff (W4)
+# ---------------------------------------------------------------------------
+
+
+class _BoomClient:
+    """A client whose `.get()` always fails, simulating an unreachable server."""
+
+    def get(self, path: str, params: dict | None = None, timeout: float | None = None) -> dict:
+        raise RuntimeError("connection timed out")
+
+    def close(self) -> None:
+        pass
+
+
+class TestStalenessCheckFailureBackoff:
+    def test_network_failure_writes_failure_stamp(self, tmp_path):
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        with patch.object(skills_mod, "get_client", return_value=_BoomClient()):
+            warn = skills_mod.check_skill_staleness()
+        assert warn is None
+        cache = sr.read_staleness_cache()
+        assert cache is not None
+        assert cache["failed"] is True
+
+    def test_second_call_within_backoff_window_makes_no_network_call(self, tmp_path):
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        with patch.object(skills_mod, "get_client", return_value=_BoomClient()):
+            assert skills_mod.check_skill_staleness() is None
+
+        mock_get_client = MagicMock()
+        with patch.object(skills_mod, "get_client", mock_get_client):
+            assert skills_mod.check_skill_staleness() is None
+        assert not mock_get_client.called
+
+    def test_success_after_expired_failure_stamp_overwrites_it(self, tmp_path):
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        # Seed an already-expired failure stamp so this check hits the
+        # network again instead of backing off.
+        sr.STALENESS_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        sr.STALENESS_CACHE_PATH.write_text(
+            json.dumps({"checked_at": time.time() - sr.STALENESS_FAILURE_TTL_SECONDS - 1, "failed": True}),
+            encoding="utf-8",
+        )
+
+        fake = _FakeClient({"/skills/versions/": {"results": {"foo": "2.0.0"}}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            warn = skills_mod.check_skill_staleness()
+        assert warn is not None
+        assert "foo" in warn
+
+        cache = sr.read_staleness_cache()
+        assert cache is not None
+        assert "failed" not in cache
+        assert cache["results"] == {"foo": "2.0.0"}
+
+    def test_successful_check_passes_a_short_timeout(self, tmp_path):
+        sr.write_registry({"skills": {"foo": {"version": "1.0.0", "checksum": "c", "paths": [], "installed_at": "x"}}})
+        fake = _FakeClient({"/skills/versions/": {"results": {"foo": "1.0.0"}}})
+        with patch.object(skills_mod, "get_client", return_value=fake):
+            skills_mod.check_skill_staleness()
+        assert fake.calls == [("/skills/versions/", {"names": "foo"})]
+        # A background per-run check shouldn't inherit the client's full
+        # 30s default — it should ask for something much shorter.
+        assert fake.timeouts == [skills_mod.STALENESS_CHECK_TIMEOUT_SECONDS]
+        assert skills_mod.STALENESS_CHECK_TIMEOUT_SECONDS < 30


### PR DESCRIPTION
## Summary

- Adds `tl skill list [--all] / download <name> [--force] / update / remove <name>`: installs the skills available to your organization into the same agent skill directories as bundled skills (Claude Code, OpenCode, Gemini/Codex), tracked with a local registry (`~/.config/tl/skills.json`) and per-directory `.tl-skill.json` markers, installed atomically with client-side path-safety re-validation.
- `tl setup` and `tl update` now skip marker-bearing downloaded skill directories, so routine re-syncs can no longer clobber a downloaded skill that shares a name with a bundled one.
- An unobtrusive once-daily check warns when installed skills are outdated; it is failure-silent and backs off (short TTL + 5s timeout) so an unreachable server never slows the CLI.

## Part of a 3-repo feature (merge in order)

1. thoughtleaders (server) — ThoughtLeaders-io/thoughtleaders#4206 — **merge and deploy first**.
2. tl-internal — `skill upload` (ThoughtLeaders-io/tl-internal#16).
3. **This PR** (tl-cli) — merge/release last.

## Test plan

- `pytest tests/` — 445 passing (415 baseline + registry, command, staleness-backoff, name-validation, atomic-write, and setup-marker-respect tests).
- `ruff check` / `ruff format --check` clean on changed files (pre-existing repo lint debt in untouched files excluded).
- `tl skill --help` renders; live end-to-end run drove download → update → remove into an isolated HOME, and verified the clobber fix (`tl setup claude` preserved a marker-bearing downloaded skill with a skip warning).

## Rollout note

Old `tl` clients keep clobbering downloaded skills until users update to a release containing this change — hence this repo releases last, after the server is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)