### PR TITLE
Show top-up vs purchased credit pools in tl balance

### DIFF
--- a/API.md
+++ b/API.md
@@ -142,6 +142,8 @@ Useful for verifying the API key resolves to the user you expect before kicking 
 
 `GET /balance` — credit balance plus the last 10 metered calls for the org. Free.
 
+`balance` is the combined total of two pools: `topup_balance` (plan-granted credits, reset to the plan allowance each top-up period, spent first) and `purchased_balance` (bought credits — they survive top-up resets, are spent last, and keep working after the per-user session quota is exhausted).
+
 ```bash
 curl -sS "$TL_API_BASE/balance" \
   -H "Authorization: Bearer $TL_API_KEY" \
@@ -155,6 +157,8 @@ print(get('/balance'))
 ```json
 {
   "balance": 9995.88,
+  "topup_balance": 8995.88,
+  "purchased_balance": 1000.00,
   "allow_overage": false,
   "recent_usage": [
     {

--- a/src/tl_cli/commands/balance.py
+++ b/src/tl_cli/commands/balance.py
@@ -44,6 +44,12 @@ def balance(
         allow_overage = data.get("allow_overage", False)
 
         console.print(f"\n[bold]Credit Balance:[/bold] [cyan]{balance_val}[/cyan] credits")
+        # Older servers return only the combined balance; newer ones split it
+        # into the plan-granted (top-up) pool and the purchased pool.
+        topup_val = data.get("topup_balance")
+        purchased_val = data.get("purchased_balance")
+        if topup_val is not None and purchased_val is not None:
+            console.print(f"[dim]Plan (top-up) credits: {topup_val} · Purchased: {purchased_val}[/dim]")
         if allow_overage:
             console.print("[dim]Overage: enabled[/dim]")
 


### PR DESCRIPTION
## Summary

- `tl balance` now renders the pool breakdown when the server returns it: plan (top-up) credits are spent first; purchased credits survive top-up resets and keep working past the per-user session quota.
- Back-compatible in both directions — older servers without `topup_balance` / `purchased_balance` render exactly as before.
- `API.md` documents the new `/balance` fields and pool semantics.

## Test plan

- `tl balance` against a server with the pool fields shows the breakdown line; against an older server the output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)