### PR TITLE
Add tl reports link / unlink commands

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.9.4"
+version = "0.9.5"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -217,6 +217,8 @@ tl snapshots channel <id>              # Channel metrics over time (Firebolt-bac
 tl snapshots video <id> --channel <id> # Video view curve (--channel required!)
 tl reports                             # List saved reports
 tl reports run <id>                    # Run a saved report
+tl reports link <id> --source <id> --entity <e> [--type include|exclude] [--source-side included|excluded]  # Link another report in as a live entity source
+tl reports unlink <id> --source <id> [--entity <e>] [--type include|exclude]  # Remove report links (all from that source unless narrowed)
 tl <entity> comment-list <id>          # List comments on a sponsorship/channel/brand/upload
 tl <entity> comment-add <id> "msg"     # Add a comment
 tl <entity> comment-edit <comment-id> "msg"  # Edit own comment (author or superuser)
@@ -260,6 +262,28 @@ process that never modifies or removes existing entries — not available via th
 clear. This is currently the only editable profile field; anything else returns a 400 listing
 the editable surface. Use it for account-handling notes meant for the internal team — it is
 never shown to the customer.
+
+**Report linking.** `tl reports link` attaches another report to a report as a **live**
+include/exclude entity source — the target report's results are filtered by the source
+report's entities (channels, brands, articles, or sponsorships) and stay in sync as the
+source changes. This is the "include/exclude entities from another report" feature the
+web UI offers, and it differs from `tl bulk-import`, which copies a **frozen snapshot**
+of IDs. `--type` defaults to `include`; `--source-side` defaults to `included` (pass
+`excluded` to pull the source report's excluded entities instead of its results).
+Requires owning the target report (or full access), and the source report must be
+visible to you. Linking a report to itself, an exact duplicate link, or an unknown key
+comes back as a 400.
+
+`tl reports unlink` removes links: with only `--source`, every link pulling from that
+source report is removed; add `--entity` and/or `--type` to remove just the matching
+one. No matching link comes back as a 404, never a silent no-op.
+
+```bash
+tl reports link 1234 --source 5678 --entity channels                 # include source's channels
+tl reports link 1234 --source 5678 --entity brands --type exclude    # exclude source's brands
+tl reports unlink 1234 --source 5678                                 # remove all links from 5678
+tl reports unlink 1234 --source 5678 --entity brands --type exclude  # remove one specific link
+```
 
 ### Creating and vetting sponsorships
 

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"

--- a/src/tl_cli/commands/reports.py
+++ b/src/tl_cli/commands/reports.py
@@ -672,3 +672,109 @@ def update_report(
         handle_api_error(e)
     finally:
         client.close()
+
+
+LINK_ENTITIES = ("channels", "brands", "articles", "sponsorships")
+LINK_TYPES = ("include", "exclude")
+LINK_SOURCE_SIDES = ("included", "excluded")
+
+
+@app.command("link")
+def link_report(
+    report_id: int = typer.Argument(..., help="Target report ID (the report being filtered)"),
+    source: int = typer.Option(..., "--source", "-s", help="Source report ID whose entities are pulled in"),
+    entity: str = typer.Option(..., "--entity", "-e", help=f"Entity type: one of {', '.join(LINK_ENTITIES)}"),
+    filter_type: str = typer.Option(
+        "include", "--type", "-t", help="How the source acts on the target: include or exclude"
+    ),
+    source_side: str = typer.Option(
+        "included",
+        "--source-side",
+        help="Pull the source report's results ('included', default) or its excluded entities ('excluded')",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Link another report into this report as an include/exclude entity source.
+
+    The target report's results are then filtered by the source report's
+    entities of the given type — the same linking the web UI offers, kept
+    in sync automatically (unlike a bulk-import snapshot).
+
+    Examples:
+        tl reports link 1234 --source 5678 --entity channels --type include
+        tl reports link 1234 --source 5678 --entity brands --type exclude
+    """
+    if entity not in LINK_ENTITIES:
+        err.print(f"[red]--entity must be one of: {', '.join(LINK_ENTITIES)}[/red]")
+        raise typer.Exit(2)
+    if filter_type not in LINK_TYPES:
+        err.print(f"[red]--type must be one of: {', '.join(LINK_TYPES)}[/red]")
+        raise typer.Exit(2)
+    if source_side not in LINK_SOURCE_SIDES:
+        err.print(f"[red]--source-side must be one of: {', '.join(LINK_SOURCE_SIDES)}[/red]")
+        raise typer.Exit(2)
+
+    fmt = detect_format(json_output, False, False, toon_output)
+    client = get_client()
+    try:
+        data = client.post(
+            f"/reports/{report_id}/link",
+            json_body={
+                "source_report_id": source,
+                "entity": entity,
+                "filter_type": filter_type,
+                "campaign_entity_type": source_side,
+            },
+        )
+        output_single(data, fmt)
+    except ApiError as e:
+        handle_api_error(e)
+    finally:
+        client.close()
+
+
+@app.command("unlink")
+def unlink_report(
+    report_id: int = typer.Argument(..., help="Target report ID (the report holding the link)"),
+    source: int = typer.Option(..., "--source", "-s", help="Source report ID to unlink"),
+    entity: str | None = typer.Option(
+        None, "--entity", "-e", help=f"Only remove links of this entity type: one of {', '.join(LINK_ENTITIES)}"
+    ),
+    filter_type: str | None = typer.Option(
+        None, "--type", "-t", help="Only remove links of this type: include or exclude"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Remove a report link created with `tl reports link`.
+
+    Without --entity/--type, removes every link pulling from the source
+    report. Narrow with --entity and/or --type to remove a specific one.
+
+    Examples:
+        tl reports unlink 1234 --source 5678
+        tl reports unlink 1234 --source 5678 --entity channels --type exclude
+    """
+    if entity is not None and entity not in LINK_ENTITIES:
+        err.print(f"[red]--entity must be one of: {', '.join(LINK_ENTITIES)}[/red]")
+        raise typer.Exit(2)
+    if filter_type is not None and filter_type not in LINK_TYPES:
+        err.print(f"[red]--type must be one of: {', '.join(LINK_TYPES)}[/red]")
+        raise typer.Exit(2)
+
+    body: dict = {"source_report_id": source}
+    if entity is not None:
+        body["entity"] = entity
+    if filter_type is not None:
+        body["filter_type"] = filter_type
+
+    fmt = detect_format(json_output, False, False, toon_output)
+    client = get_client()
+    try:
+        data = client.post(f"/reports/{report_id}/unlink", json_body=body)
+        output_single(data, fmt)
+    except ApiError as e:
+        handle_api_error(e)
+    finally:
+        client.close()

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -215,3 +215,54 @@ class TestUpdateArgValidation:
         result = runner.invoke(app, ["update", "12345", '"just a string"'])
         assert result.exit_code == 1
         assert "json object" in (result.stderr or result.output).lower()
+
+
+# ---------------------------------------------------------------------------
+# tl reports link / unlink — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestLinkArgValidation:
+    def test_invalid_entity_rejected(self) -> None:
+        result = runner.invoke(app, ["link", "1", "--source", "2", "--entity", "widgets"])
+        assert result.exit_code == 2
+        assert "entity" in result.output
+
+    def test_invalid_type_rejected(self) -> None:
+        result = runner.invoke(
+            app, ["link", "1", "--source", "2", "--entity", "channels", "--type", "maybe"]
+        )
+        assert result.exit_code == 2
+        assert "type" in result.output
+
+    def test_invalid_source_side_rejected(self) -> None:
+        result = runner.invoke(
+            app,
+            ["link", "1", "--source", "2", "--entity", "channels", "--source-side", "both"],
+        )
+        assert result.exit_code == 2
+        assert "source-side" in result.output
+
+    def test_source_required(self) -> None:
+        result = runner.invoke(app, ["link", "1", "--entity", "channels"])
+        assert result.exit_code == 2
+
+    def test_entity_required(self) -> None:
+        result = runner.invoke(app, ["link", "1", "--source", "2"])
+        assert result.exit_code == 2
+
+
+class TestUnlinkArgValidation:
+    def test_invalid_entity_rejected(self) -> None:
+        result = runner.invoke(app, ["unlink", "1", "--source", "2", "--entity", "widgets"])
+        assert result.exit_code == 2
+        assert "entity" in result.output
+
+    def test_invalid_type_rejected(self) -> None:
+        result = runner.invoke(app, ["unlink", "1", "--source", "2", "--type", "maybe"])
+        assert result.exit_code == 2
+        assert "type" in result.output
+
+    def test_source_required(self) -> None:
+        result = runner.invoke(app, ["unlink", "1"])
+        assert result.exit_code == 2


### PR DESCRIPTION
## Summary
- New `tl reports link <id> --source <id> --entity <channels|brands|articles|sponsorships> [--type include|exclude] [--source-side included|excluded]` — attach another report to a report as a live include/exclude entity source (kept in sync, unlike a `bulk-import` snapshot).
- New `tl reports unlink <id> --source <id> [--entity …] [--type …]` — remove such links; without narrowing flags it removes every link from that source, and a no-match comes back as an error rather than a silent no-op.
- Documented in the tl skill's command surface and update-records section; version bumped to 0.9.5.

## Test plan
- `pytest tests/test_reports.py` — 8 new arg-validation tests for both commands (29 total in the module, full suite 464 passing).
- `tl reports link --help` / `tl reports unlink --help` render correctly.
- Server-side endpoints land in ThoughtLeaders-io/thoughtleaders#4229 — that PR should merge and deploy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)