### PR TITLE
Fix stale schema doc: adlink url->urls rename, channel reach hallucination

### DIFF
--- a/skills/tl/references/postgres-schema.md
+++ b/skills/tl/references/postgres-schema.md
@@ -25,6 +25,7 @@ The profile table is tightly coupled with the brand table for media buyers, so m
 > - ❌ `youtube_id` (on channel) — use `external_channel_id`.
 > - ❌ `msn_join_date` (on channel) — use `media_selling_network_join_date`.
 > - ❌ `mbn_join_date` (on profile) — use `media_buying_network_join_date`.
+> - ❌ `url` — renamed to `urls` (array) by migration 0010 (2026-07-16, "AdLink.url becomes urls"). A sponsorship can carry several URLs now; use `urls` — e.g. `urls[1]` for the first entry, or `array_to_string(urls, ', ')` to flatten.
 
 #### Key Columns for the thoughtleaders_adlink table
 
@@ -58,6 +59,7 @@ The profile table is tightly coupled with the brand table for media buyers, so m
 | `performance_grade` | int | Performance rating (see business-glossary) |
 | `article_id` | varchar | Compound `<channel_id>:<youtube_id>` — links to ES `_id` and ES `id` field |
 | `created_where` | varchar | What mechanism / software / agent created the record |
+| `urls` | varchar(600)[] (array) | Destination/reference URLs for the sponsorship. ⚠️ Renamed from the old singular `url` column by migration 0010 (2026-07-16) — a sponsorship can carry several URLs now. Never NULL (empty array `{}` when none set). Use `urls[1]` for "the" URL when a single value is needed, or `array_to_string(urls, ', ')` to flatten for display. |
 
 #### `publish_status` Constants
 
@@ -204,7 +206,7 @@ A channel can have multiple adspots (different sellers: talent manager, direct, 
 
 When composing `SELECT ... FROM thoughtleaders_channel ...`, do not improvise column names from semantic intuition — consult the output of `tl schema pg thoughtleaders_channel` or the column table above. The `tl schema` command is authoritative. Failed guesses return *"column '\<name\>' does not exist"* and cost a round-trip. Recurring problems:
 
-- Subscriber count is in the field named `subscribers`
+- ❌ `reach` — this column does NOT exist on Postgres. Use `subscribers`. (The Elasticsearch channel doc uses `reach` as a legacy alias for the same value — see [elasticsearch-schema.md](elasticsearch-schema.md) — but Postgres never had that name; don't carry the ES field name over when switching to a `tl db pg` query.)
 - Projected views is in the field named `projected_views`
 - ❌ **Suffix/qualifier variants of date columns** (e.g. an `_max` / `latest_` / `_date` form when the canonical column has neither). Date columns  use bare names.
 - ❌ **Platform-name-prefixed ID forms** (e.g. a platform-name prefix when the canonical column uses a neutral `external_` prefix). See the column table for the actual ID column.


### PR DESCRIPTION
## Why

A daily CLI-usage-log review surfaced two field-name hallucinations that hit a real customer session — Allan Lires (Boot.dev), during a delivery-reconciliation audit. Each occurrence costs a wasted `describe`/schema round-trip before the LLM self-corrects.

## What

**`a.url` (hit 20×)** — migration 0010 (2026-07-16, "AdLink.url becomes urls") renamed `thoughtleaders_adlink`'s singular `url` column to `urls`, an array (`varchar(600)[]`, never NULL, default `{}`) supporting multiple destination URLs per sponsorship. The schema doc never mentioned the rename or the new column at all — nothing pointed an LLM away from the old name.

**`reach` (hit 12×)** — channel audience size is `subscribers` on Postgres, but the doc only had a soft one-line mention ("Subscriber count is in the field named `subscribers`") buried in a bullet list — not the sharp "❌ column DOES NOT exist" callout style already proven elsewhere in this doc (the adlink section's hallucination box). `reach` is a real column name, just on the Elasticsearch side (a legacy alias, see `elasticsearch-schema.md`) — very plausibly where the confusion comes from when switching from an ES-backed query to a raw Postgres one.

## Fix

- Added `url` → `urls` to the adlink hallucination callout box, plus a proper `urls` row in the Key Columns table (type, nullability, and how to get "the" URL from the array).
- Upgraded the soft `reach`/`subscribers` mention to a sharp ❌-prefixed callout, cross-referencing the ES doc so the actual source of confusion is explained, not just patched over.

Docs-only change — no code touched, CI (Python unit tests) unaffected.