### PR TITLE
feat(memory): tl memory show/add/set

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.9.5"
+version = "0.9.6"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -287,7 +287,7 @@ tl reports unlink 1234 --source 5678 --entity brands --type exclude  # remove on
 
 ### Profile memory
 
-`profile_memory` is the free-text summary of who a user is and what they want from
+Profile memory is the free-text summary of who a user is and what they want from
 sponsorships. The onboarding interview writes it first; `tl memory` keeps it current
 afterwards. **This is the standard way to update user data** — prefer it over any
 direct database write.
@@ -295,7 +295,7 @@ direct database write.
 ```bash
 tl memory show                            # Your memory + the preferences derived from it (free)
 tl memory show --profile-id <id>          # Someone else's memory (full-access only) (free)
-tl memory add "<fact>"                    # Fold one new fact in — the server merges it (free)
+tl memory add "<fact>"                    # Fold one new fact into the existing memory (free)
 tl memory set "<blob>"                    # Replace the memory wholesale (free)
 tl memory set --from-file <path>          # Same, reading the text from a file (free)
 ```
@@ -307,12 +307,19 @@ tl memory add "Stopped doing finance ads. Now targeting 18-24 in the US."
 tl memory set --from-file ./memory.txt
 ```
 
-`add` is the verb to reach for almost every time: the server merges the new fact into
-the existing memory, keeping what's still true and replacing only what the fact
-contradicts. `set` replaces the memory wholesale and, unlike `add`, isn't length-guarded
-— treat it as the repair hatch for when a merge has damaged a memory, not as a routine
-update path. `add` and `set` always write to the **caller's own** profile regardless of
-permissions; only `show --profile-id` can reach someone else's, and that's full-access only.
+`add` is the verb to reach for almost every time: the new fact is folded into the
+existing memory, keeping what's still true and replacing only what the fact
+contradicts. Never read the memory, edit it yourself and write it back with `set` when
+`add` would do — one `add` per fact is the whole interface. `add` takes noticeably
+longer than the other two; that is expected, so let it finish rather than retrying,
+because a repeated `add` can land twice.
+
+`set` replaces the memory wholesale and, unlike `add`, accepts a short replacement for
+a long memory — treat it as the repair hatch for when a merge has damaged a memory,
+not as a routine update path. Blank replacement text is refused rather than erasing the
+memory, and text beyond 50,000 characters is not kept. `add` and `set` always write to
+the **caller's own** profile regardless of permissions; only `show --profile-id` can
+reach someone else's, and that's full-access only.
 
 ### Creating and vetting sponsorships
 

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -285,6 +285,35 @@ tl reports unlink 1234 --source 5678                                 # remove al
 tl reports unlink 1234 --source 5678 --entity brands --type exclude  # remove one specific link
 ```
 
+### Profile memory
+
+`profile_memory` is the free-text summary of who a user is and what they want from
+sponsorships. The onboarding interview writes it first; `tl memory` keeps it current
+afterwards. **This is the standard way to update user data** — prefer it over any
+direct database write.
+
+```bash
+tl memory show                            # Your memory + the preferences derived from it (free)
+tl memory show --profile-id <id>          # Someone else's memory (full-access only) (free)
+tl memory add "<fact>"                    # Fold one new fact in — the server merges it (free)
+tl memory set "<blob>"                    # Replace the memory wholesale (free)
+tl memory set --from-file <path>          # Same, reading the text from a file (free)
+```
+
+Examples:
+```bash
+tl memory show --profile-id 8871
+tl memory add "Stopped doing finance ads. Now targeting 18-24 in the US."
+tl memory set --from-file ./memory.txt
+```
+
+`add` is the verb to reach for almost every time: the server merges the new fact into
+the existing memory, keeping what's still true and replacing only what the fact
+contradicts. `set` replaces the memory wholesale and, unlike `add`, isn't length-guarded
+— treat it as the repair hatch for when a merge has damaged a memory, not as a routine
+update path. `add` and `set` always write to the **caller's own** profile regardless of
+permissions; only `show --profile-id` can reach someone else's, and that's full-access only.
+
 ### Creating and vetting sponsorships
 
 This is the end-to-end workflow for proposing a sponsorship, then moving it through the funnel as the two sides respond. Three create commands plus `tl sponsorships update` cover every state transition the CLI exposes.

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -312,7 +312,9 @@ existing memory, keeping what's still true and replacing only what the fact
 contradicts. Never read the memory, edit it yourself and write it back with `set` when
 `add` would do — one `add` per fact is the whole interface. `add` takes noticeably
 longer than the other two; that is expected, so let it finish rather than retrying,
-because a repeated `add` can land twice.
+because a repeated `add` can land twice. A fact is one statement, not a document:
+anything past 4,000 characters is rejected, so split a long update into several `add`
+calls rather than sending it as one.
 
 `set` replaces the memory wholesale and, unlike `add`, accepts a short replacement for
 a long memory — treat it as the repair hatch for when a merge has damaged a memory,

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"

--- a/src/tl_cli/client/http.py
+++ b/src/tl_cli/client/http.py
@@ -26,8 +26,8 @@ class TLClient:
     def get(self, path: str, params: dict | None = None, timeout: float | None = None) -> dict:
         return self._request("GET", path, params=params, timeout=timeout)
 
-    def post(self, path: str, json_body: dict | None = None) -> dict:
-        return self._request("POST", path, json_body=json_body)
+    def post(self, path: str, json_body: dict | None = None, timeout: float | None = None) -> dict:
+        return self._request("POST", path, json_body=json_body, timeout=timeout)
 
     def patch(self, path: str, json_body: dict | None = None) -> dict:
         return self._request("PATCH", path, json_body=json_body)

--- a/src/tl_cli/commands/memory.py
+++ b/src/tl_cli/commands/memory.py
@@ -1,6 +1,6 @@
 """tl memory — read and update your profile memory.
 
-`profile_memory` is the free-text summary of who you are and what you want from
+Your profile memory is the free-text summary of who you are and what you want from
 sponsorships. The onboarding interview writes it first; these commands are how it
 stays current afterwards.
 """
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.markup import escape as rich_escape
 
 from tl_cli._typer_utils import AlphaSortedTyperGroup
 from tl_cli.client.errors import ApiError, handle_api_error
@@ -17,10 +18,15 @@ from tl_cli.output.formatter import detect_format, output_single
 
 app = typer.Typer(cls=AlphaSortedTyperGroup, help="Your profile memory (show; add a fact; replace)")
 
+# `add` folds the fact into the existing memory with a model call whose duration
+# scales with how much memory there is to rewrite, so it can run far past the
+# client's 30s default. `set` is a plain replace and needs no extra room.
+_ADD_TIMEOUT_SECONDS = 180.0
+
 
 @app.command("show")
 def show_cmd(
-    profile_id: int = typer.Option(None, "--profile-id", help="Another profile's memory (full-access only)"),
+    profile_id: int | None = typer.Option(None, "--profile-id", help="Another profile's memory (full-access only)"),
     json_output: bool = typer.Option(False, "--json", help="JSON output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
 ) -> None:
@@ -52,9 +58,9 @@ def add_cmd(
 ) -> None:
     """Fold one new fact into your profile memory.
 
-    The server merges it into what's already there — keeping everything still
-    true and replacing only what the new fact contradicts. Always writes to your
-    own profile.
+    The fact is merged into what's already there — everything still true is kept,
+    and only what the new fact contradicts is replaced. Always writes to your own
+    profile.
 
     Examples:
         tl memory add "We stopped doing finance sponsorships."
@@ -67,7 +73,7 @@ def add_cmd(
 
     client = get_client()
     try:
-        data = client.post("/memory", json_body={"fact": fact.strip()})
+        data = client.post("/memory", json_body={"fact": fact.strip()}, timeout=_ADD_TIMEOUT_SECONDS)
         output_single(data, fmt)
     except ApiError as e:
         handle_api_error(e)
@@ -78,7 +84,7 @@ def add_cmd(
 @app.command("set")
 def set_cmd(
     memory: str = typer.Argument(None, help="The full replacement text"),
-    from_file: Path = typer.Option(None, "--from-file", help="Read the replacement text from a file"),
+    from_file: Path | None = typer.Option(None, "--from-file", help="Read the replacement text from a file"),
     json_output: bool = typer.Option(False, "--json", help="JSON output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
 ) -> None:
@@ -95,21 +101,45 @@ def set_cmd(
     fmt = detect_format(json_output, False, False, toon_output)
     err = Console(stderr=True)
 
-    if (memory is None) == (from_file is None):
+    if memory is not None and from_file is not None:
         err.print("[red]Error:[/red] pass either the replacement text or --from-file, not both.")
+        raise typer.Exit(1)
+    if memory is None and from_file is None:
+        err.print("[red]Error:[/red] pass the replacement text, or --from-file to read it from a file.")
         raise typer.Exit(1)
 
     if from_file is not None:
         try:
             memory = from_file.read_text(encoding="utf-8")
-        except OSError as exc:
-            err.print(f"[red]Error:[/red] could not read {from_file}: {exc}")
+        # A non-text file raises UnicodeDecodeError, a ValueError rather than an
+        # OSError. The path and the error text are escaped because a bracket in
+        # either would abort on a markup error and lose the message itself.
+        except (OSError, UnicodeDecodeError) as exc:
+            err.print(f"[red]Error:[/red] could not read {rich_escape(str(from_file))}: {rich_escape(str(exc))}")
             raise typer.Exit(1)
+
+    # A blank replacement erases the whole memory, and the two ways to arrive at one
+    # — a stray empty argument, or a --from-file that was never written — are both
+    # mistakes rather than an intent to erase.
+    memory = memory.strip()
+    if not memory:
+        source = f"{rich_escape(str(from_file))} is empty" if from_file is not None else "the replacement text is empty"
+        err.print(f"[red]Error:[/red] {source}; that would erase your whole memory.")
+        err.print("Pass the text you want stored, or use [bold]tl memory add[/bold] to change one thing at a time.")
+        raise typer.Exit(1)
 
     client = get_client()
     try:
         data = client.post("/memory", json_body={"memory": memory})
         output_single(data, fmt)
+        # A replacement past the size limit is kept only up to it. The stored length
+        # is in the output either way, but nothing there says text went missing.
+        stored = data.get("profile_memory")
+        if isinstance(stored, str) and len(stored) < len(memory):
+            err.print(
+                f"[bold yellow]Warning:[/bold yellow] [yellow]stored {len(stored):,} of "
+                f"{len(memory):,} characters — the rest was past the size limit.[/yellow]"
+            )
     except ApiError as e:
         handle_api_error(e)
     finally:

--- a/src/tl_cli/commands/memory.py
+++ b/src/tl_cli/commands/memory.py
@@ -83,7 +83,7 @@ def add_cmd(
 
 @app.command("set")
 def set_cmd(
-    memory: str = typer.Argument(None, help="The full replacement text"),
+    memory: str | None = typer.Argument(None, help="The full replacement text"),
     from_file: Path | None = typer.Option(None, "--from-file", help="Read the replacement text from a file"),
     json_output: bool = typer.Option(False, "--json", help="JSON output"),
     toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
@@ -110,7 +110,10 @@ def set_cmd(
 
     if from_file is not None:
         try:
-            memory = from_file.read_text(encoding="utf-8")
+            # utf-8-sig, not utf-8: an editor that writes a byte-order mark leaves it
+            # as the first character of the text, where it is not whitespace, survives
+            # the strip below, and is stored invisibly at the head of the memory.
+            memory = from_file.read_text(encoding="utf-8-sig")
         # A non-text file raises UnicodeDecodeError, a ValueError rather than an
         # OSError. The path and the error text are escaped because a bracket in
         # either would abort on a markup error and lose the message itself.
@@ -121,7 +124,7 @@ def set_cmd(
     # A blank replacement erases the whole memory, and the two ways to arrive at one
     # — a stray empty argument, or a --from-file that was never written — are both
     # mistakes rather than an intent to erase.
-    memory = memory.strip()
+    memory = (memory or "").strip()
     if not memory:
         source = f"{rich_escape(str(from_file))} is empty" if from_file is not None else "the replacement text is empty"
         err.print(f"[red]Error:[/red] {source}; that would erase your whole memory.")

--- a/src/tl_cli/commands/memory.py
+++ b/src/tl_cli/commands/memory.py
@@ -1,0 +1,116 @@
+"""tl memory — read and update your profile memory.
+
+`profile_memory` is the free-text summary of who you are and what you want from
+sponsorships. The onboarding interview writes it first; these commands are how it
+stays current afterwards.
+"""
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from tl_cli._typer_utils import AlphaSortedTyperGroup
+from tl_cli.client.errors import ApiError, handle_api_error
+from tl_cli.client.http import get_client
+from tl_cli.output.formatter import detect_format, output_single
+
+app = typer.Typer(cls=AlphaSortedTyperGroup, help="Your profile memory (show; add a fact; replace)")
+
+
+@app.command("show")
+def show_cmd(
+    profile_id: int = typer.Option(None, "--profile-id", help="Another profile's memory (full-access only)"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Show your profile memory and the preferences derived from it.
+
+    Examples:
+        tl memory show
+        tl memory show --json
+        tl memory show --profile-id 8871
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    params = {"profile_id": profile_id} if profile_id is not None else {}
+
+    client = get_client()
+    try:
+        data = client.get("/memory", params=params)
+        output_single(data, fmt)
+    except ApiError as e:
+        handle_api_error(e)
+    finally:
+        client.close()
+
+
+@app.command("add")
+def add_cmd(
+    fact: str = typer.Argument(..., help="One new fact about you"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Fold one new fact into your profile memory.
+
+    The server merges it into what's already there — keeping everything still
+    true and replacing only what the new fact contradicts. Always writes to your
+    own profile.
+
+    Examples:
+        tl memory add "We stopped doing finance sponsorships."
+        tl memory add "Now targeting 18-24 in the US."
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    if not fact.strip():
+        Console(stderr=True).print("[red]Error:[/red] fact cannot be empty.")
+        raise typer.Exit(1)
+
+    client = get_client()
+    try:
+        data = client.post("/memory", json_body={"fact": fact.strip()})
+        output_single(data, fmt)
+    except ApiError as e:
+        handle_api_error(e)
+    finally:
+        client.close()
+
+
+@app.command("set")
+def set_cmd(
+    memory: str = typer.Argument(None, help="The full replacement text"),
+    from_file: Path = typer.Option(None, "--from-file", help="Read the replacement text from a file"),
+    json_output: bool = typer.Option(False, "--json", help="JSON output"),
+    toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
+) -> None:
+    """Replace your profile memory wholesale.
+
+    The repair hatch for when a merge has gone wrong — unlike `add`, this is not
+    length-guarded, so it will happily replace a long blob with a short one.
+    Prefer `add` for ordinary updates.
+
+    Examples:
+        tl memory set "Runs a finance channel. Avoids crypto."
+        tl memory set --from-file ./memory.txt
+    """
+    fmt = detect_format(json_output, False, False, toon_output)
+    err = Console(stderr=True)
+
+    if (memory is None) == (from_file is None):
+        err.print("[red]Error:[/red] pass either the replacement text or --from-file, not both.")
+        raise typer.Exit(1)
+
+    if from_file is not None:
+        try:
+            memory = from_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            err.print(f"[red]Error:[/red] could not read {from_file}: {exc}")
+            raise typer.Exit(1)
+
+    client = get_client()
+    try:
+        data = client.post("/memory", json_body={"memory": memory})
+        output_single(data, fmt)
+    except ApiError as e:
+        handle_api_error(e)
+    finally:
+        client.close()

--- a/src/tl_cli/main.py
+++ b/src/tl_cli/main.py
@@ -22,6 +22,7 @@ from tl_cli.commands.channels import app as channels_app
 from tl_cli.commands.db import app as db_app
 from tl_cli.commands.deals import app as deals_app
 from tl_cli.commands.matches import app as matches_app
+from tl_cli.commands.memory import app as memory_app
 from tl_cli.commands.profiles import app as profiles_app
 from tl_cli.commands.proposals import app as proposals_app
 from tl_cli.commands.recommender import app as recommender_app
@@ -104,6 +105,7 @@ app.add_typer(deals_app, name="deals")
 app.add_typer(uploads_app, name="uploads")
 app.add_typer(channels_app, name="channels")
 app.add_typer(brands_app, name="brands")
+app.add_typer(memory_app, name="memory")
 app.add_typer(profiles_app, name="profiles")
 app.add_typer(recommender_app, name="recommender")
 app.add_typer(snapshots_app, name="snapshots")

--- a/src/tl_cli/output/formatter.py
+++ b/src/tl_cli/output/formatter.py
@@ -375,6 +375,12 @@ def _output_detail(record: dict) -> None:
     If a value is a non-empty list of dicts, it's rendered as an indented
     sub-table beneath its label instead of stringified. Empty lists show
     `(none)` to signal "no entries" explicitly rather than printing `[]`.
+
+    Field names and values are both data, never markup: a square-bracketed
+    token ("[/finance]" in a free-text note, a `SELECT ... AS "[x]"` alias) is
+    otherwise read as a Rich tag and either swallows the word or aborts the
+    whole command with a markup error. Everything interpolated below is
+    escaped; only the styling this function itself adds stays live.
     """
     console = Console()
     nested_items = [(k, v) for k, v in record.items() if _is_list_of_dicts(v)]
@@ -389,33 +395,35 @@ def _output_detail(record: dict) -> None:
             display = json.dumps(value, default=str)
         else:
             display = value
-        label = f"[bold]{key:<{max_key_len}}[/bold]"
-        # Values are data, never markup. A free-text field holding a square-bracketed
-        # token ("[/finance]") is otherwise read as a Rich tag and either swallows the
-        # word or aborts the whole command with a markup error.
+        # Escape the padded label, not the bare key: the escape only adds
+        # backslashes Rich consumes, so the rendered width still lines up.
+        label = f"[bold]{rich_escape(f'{key:<{max_key_len}}')}[/bold]"
         console.print(f"  {label}  {rich_escape(str(display))}")
 
     for key, rows in nested_items:
-        console.print(f"\n  [bold]{key}[/bold] ({len(rows)}):")
+        console.print(f"\n  [bold]{rich_escape(key)}[/bold] ({len(rows)}):")
         sub_cols = list(rows[0].keys())
         sub_table = Table(show_header=True, padding=(0, 1))
         for col in sub_cols:
             kwargs: dict = {"overflow": "ellipsis", "max_width": 40}
             if col in _RIGHT_ALIGN_COLS:
                 kwargs["justify"] = "right"
-            sub_table.add_column(col, **kwargs)
+            sub_table.add_column(rich_escape(col), **kwargs)
         for row in rows:
             sub_table.add_row(*[_format_cell(row.get(col)) for col in sub_cols])
         console.print(sub_table)
 
     for key in empty_list_items:
-        console.print(f"\n  [bold]{key}[/bold]: [dim](none)[/dim]")
+        console.print(f"\n  [bold]{rich_escape(key)}[/bold]: [dim](none)[/dim]")
 
 
 def _format_cell(value: object) -> str:
+    """Render one sub-table cell. Escaped for the same reason the detail rows are:
+    Rich reads markup in table cells too, so a bracketed token in free text would
+    vanish or abort the render."""
     if value is None:
         return ""
-    return _truncate(str(value), 40)
+    return rich_escape(_truncate(str(value), 40))
 
 
 def _output_detail_csv(record: dict) -> None:

--- a/src/tl_cli/output/formatter.py
+++ b/src/tl_cli/output/formatter.py
@@ -14,6 +14,7 @@ import sys
 
 from pytoon import encode as toon_encode
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.table import Table
 
 # Stderr console for status messages (never pollutes piped data)
@@ -389,7 +390,10 @@ def _output_detail(record: dict) -> None:
         else:
             display = value
         label = f"[bold]{key:<{max_key_len}}[/bold]"
-        console.print(f"  {label}  {display}")
+        # Values are data, never markup. A free-text field holding a square-bracketed
+        # token ("[/finance]") is otherwise read as a Rich tag and either swallows the
+        # word or aborts the whole command with a markup error.
+        console.print(f"  {label}  {rich_escape(str(display))}")
 
     for key, rows in nested_items:
         console.print(f"\n  [bold]{key}[/bold] ({len(rows)}):")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,107 @@
+"""Tests for `tl memory show / add / set`."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from tl_cli.commands import memory as memory_mod
+from tl_cli.commands.memory import app as memory_app
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    """Records get()/post() calls and returns a fixed payload."""
+
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.gets: list[tuple[str, dict]] = []
+        self.posts: list[tuple[str, dict]] = []
+
+    def get(self, path: str, params: dict | None = None) -> dict:
+        self.gets.append((path, params or {}))
+        return self.payload
+
+    def post(self, path: str, json_body: dict | None = None) -> dict:
+        self.posts.append((path, json_body or {}))
+        return self.payload
+
+    def close(self) -> None:
+        pass
+
+
+def _payload() -> dict:
+    return {
+        "profile_id": 9378,
+        "profile_memory": "Runs a finance channel.",
+        "chars": 23,
+        "updated_at": "2026-08-03T10:00:00+00:00",
+        "brand_rail_preferences": {"block_brands": ["acme"]},
+        "usage": {"credits_charged": 0, "balance_remaining": 100},
+    }
+
+
+class TestMemoryShow:
+    def test_gets_own_memory(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["show", "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.gets == [("/memory", {})]
+
+    def test_profile_id_is_passed_as_a_param(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["show", "--profile-id", "8871", "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.gets == [("/memory", {"profile_id": 8871})]
+
+
+class TestMemoryAdd:
+    def test_posts_the_fact(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["add", "Stopped doing finance sponsorships.", "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.posts == [("/memory", {"fact": "Stopped doing finance sponsorships."})]
+
+    def test_empty_fact_rejected_before_any_request(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["add", "   "])
+        assert result.exit_code == 1
+        assert fake.posts == []
+
+
+class TestMemorySet:
+    def test_posts_the_blob(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "A clean rewrite.", "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.posts == [("/memory", {"memory": "A clean rewrite."})]
+
+    def test_reads_from_file(self, tmp_path) -> None:
+        blob = tmp_path / "memory.txt"
+        blob.write_text("From a file.", encoding="utf-8")
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "--from-file", str(blob), "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.posts == [("/memory", {"memory": "From a file."})]
+
+    def test_requires_exactly_one_source(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            neither = runner.invoke(memory_app, ["set"])
+            both = runner.invoke(memory_app, ["set", "inline", "--from-file", "x.txt"])
+        assert neither.exit_code == 1
+        assert both.exit_code == 1
+        assert fake.posts == []
+
+    def test_missing_file_is_an_error_before_any_request(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "--from-file", "does-not-exist.txt"])
+        assert result.exit_code == 1
+        assert fake.posts == []

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from tl_cli.commands import memory as memory_mod
 from tl_cli.commands.memory import app as memory_app
+from tl_cli.main import app as root_app
 
 runner = CliRunner()
 
@@ -92,6 +93,17 @@ class TestMemorySet:
             result = runner.invoke(memory_app, ["set", "A clean rewrite.", "--json"])
         assert result.exit_code == 0, result.output
         assert fake.posts == [("/memory", {"memory": "A clean rewrite."})]
+
+    def test_byte_order_mark_is_not_stored(self, tmp_path) -> None:
+        """An editor that prefixes a BOM must not plant an invisible character at the
+        head of the memory — it is not whitespace, so nothing downstream removes it."""
+        blob = tmp_path / "memory.txt"
+        blob.write_text("From a file.\n", encoding="utf-8-sig")
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "--from-file", str(blob), "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.posts == [("/memory", {"memory": "From a file."})]
 
     def test_reads_from_file(self, tmp_path) -> None:
         """A text file ends with a newline that is no part of the memory."""
@@ -187,3 +199,15 @@ class TestMemorySet:
         assert result.exit_code == 1
         assert "could not read" in result.output
         assert fake.posts == []
+
+
+class TestMemoryIsReachableFromTheRootApp:
+    """The other cases drive the sub-app directly, so none of them would notice the
+    group never being mounted — `tl memory ...` is the only invocation users have."""
+
+    def test_show_runs_as_tl_memory_show(self) -> None:
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(root_app, ["memory", "show", "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.gets == [("/memory", {})]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -17,13 +17,15 @@ class _FakeClient:
         self.payload = payload
         self.gets: list[tuple[str, dict]] = []
         self.posts: list[tuple[str, dict]] = []
+        self.post_timeouts: list[float | None] = []
 
-    def get(self, path: str, params: dict | None = None) -> dict:
+    def get(self, path: str, params: dict | None = None, timeout: float | None = None) -> dict:
         self.gets.append((path, params or {}))
         return self.payload
 
-    def post(self, path: str, json_body: dict | None = None) -> dict:
+    def post(self, path: str, json_body: dict | None = None, timeout: float | None = None) -> dict:
         self.posts.append((path, json_body or {}))
+        self.post_timeouts.append(timeout)
         return self.payload
 
     def close(self) -> None:
@@ -72,6 +74,16 @@ class TestMemoryAdd:
         assert result.exit_code == 1
         assert fake.posts == []
 
+    def test_merge_gets_more_than_the_default_timeout(self) -> None:
+        """The merge rewrites the whole memory before answering, so it must not be
+        held to the client's ordinary per-request ceiling."""
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["add", "A new fact.", "--json"])
+        assert result.exit_code == 0, result.output
+        assert fake.post_timeouts == [memory_mod._ADD_TIMEOUT_SECONDS]
+        assert memory_mod._ADD_TIMEOUT_SECONDS > 30.0
+
 
 class TestMemorySet:
     def test_posts_the_blob(self) -> None:
@@ -82,8 +94,9 @@ class TestMemorySet:
         assert fake.posts == [("/memory", {"memory": "A clean rewrite."})]
 
     def test_reads_from_file(self, tmp_path) -> None:
+        """A text file ends with a newline that is no part of the memory."""
         blob = tmp_path / "memory.txt"
-        blob.write_text("From a file.", encoding="utf-8")
+        blob.write_text("From a file.\n", encoding="utf-8")
         fake = _FakeClient(_payload())
         with patch.object(memory_mod, "get_client", return_value=fake):
             result = runner.invoke(memory_app, ["set", "--from-file", str(blob), "--json"])
@@ -97,6 +110,10 @@ class TestMemorySet:
             both = runner.invoke(memory_app, ["set", "inline", "--from-file", "x.txt"])
         assert neither.exit_code == 1
         assert both.exit_code == 1
+        # Two different mistakes, so two different messages: "not both" is nonsense
+        # advice for someone who passed neither.
+        assert "--from-file" in neither.output and "not both" not in neither.output
+        assert "not both" in both.output
         assert fake.posts == []
 
     def test_missing_file_is_an_error_before_any_request(self) -> None:
@@ -104,4 +121,69 @@ class TestMemorySet:
         with patch.object(memory_mod, "get_client", return_value=fake):
             result = runner.invoke(memory_app, ["set", "--from-file", "does-not-exist.txt"])
         assert result.exit_code == 1
+        assert fake.posts == []
+
+    def test_unreadable_file_encoding_is_an_error_before_any_request(self, tmp_path) -> None:
+        """A non-text file must fail as a read error, not as a decode traceback
+        escaping the command."""
+        blob = tmp_path / "memory.bin"
+        blob.write_bytes(b"\xff\xfe\x00binary")
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "--from-file", str(blob), "--json"])
+        assert result.exit_code == 1
+        # Asserted on the fixed prefix, not the path: Rich wraps a long tmp_path
+        # mid-token at the console width.
+        assert "could not read" in result.output
+        assert fake.posts == []
+
+    def test_warns_when_the_replacement_did_not_fit(self) -> None:
+        """Text past the size limit is dropped on the way in; the stored length alone
+        does not tell the user their replacement was cut."""
+        payload = _payload() | {"profile_memory": "kept", "chars": 4}
+        fake = _FakeClient(payload)
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "kept and then some more", "--json"])
+        assert result.exit_code == 0, result.output
+        assert "Warning" in result.output
+
+    def test_no_warning_when_the_replacement_was_stored_whole(self) -> None:
+        payload = _payload() | {"profile_memory": "A clean rewrite.", "chars": 16}
+        fake = _FakeClient(payload)
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "A clean rewrite.", "--json"])
+        assert result.exit_code == 0, result.output
+        assert "Warning" not in result.output
+
+    def test_blank_text_will_not_erase_the_memory(self) -> None:
+        """`set` replaces without a shrink guard, so a stray empty argument would
+        otherwise wipe the whole memory in one call."""
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "   "])
+        assert result.exit_code == 1
+        assert fake.posts == []
+
+    def test_empty_file_will_not_erase_the_memory(self, tmp_path) -> None:
+        """A --from-file target that was never written is a mistake, not a request
+        to erase — the likeliest way to lose a memory by accident."""
+        blob = tmp_path / "memory.txt"
+        blob.write_text("\n\n", encoding="utf-8")
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "--from-file", str(blob)])
+        assert result.exit_code == 1
+        assert "erase" in result.output
+        assert fake.posts == []
+
+    def test_bracketed_path_does_not_break_the_error_message(self, tmp_path) -> None:
+        """Paths are arbitrary text; a bracketed directory name must not turn a
+        read failure into a rendering failure."""
+        odd = tmp_path / "[draft]"
+        odd.mkdir()
+        fake = _FakeClient(_payload())
+        with patch.object(memory_mod, "get_client", return_value=fake):
+            result = runner.invoke(memory_app, ["set", "--from-file", str(odd / "gone.txt")])
+        assert result.exit_code == 1
+        assert "could not read" in result.output
         assert fake.posts == []

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -528,3 +528,30 @@ class TestDetailValuesAreNotMarkup:
     def test_bold_looking_value_is_not_styled_away(self, capsys):
         output_single({"note": "[bold]not a tag[/bold]"}, "table")
         assert "[bold]not a tag[/bold]" in capsys.readouterr().out
+
+    def test_bracketed_field_name_survives(self, capsys):
+        """Field names are data too — a raw-query column alias is caller-chosen text."""
+        output_single({"[bold]alias": "v", "plain": "w"}, "table")
+        lines = capsys.readouterr().out.splitlines()
+        assert any("[bold]alias" in ln for ln in lines)
+        # Escaping must not shift the value column: the backslashes Rich consumes
+        # are not printed, so both values still start at the same offset.
+        value_cols = [ln.index(v) for ln, v in zip(lines, ("v", "w"))]
+        assert value_cols[0] == value_cols[1]
+
+    def test_nested_row_value_survives(self, capsys):
+        """Sub-table cells render through Rich as well, so they need the same guard."""
+        output_single({"id": 1, "notes": [{"body": "Avoids [crypto] and [/finance]."}]}, "table")
+        out = capsys.readouterr().out
+        assert "[crypto]" in out
+        assert "[/finance]" in out
+
+    def test_nested_column_name_survives(self, capsys):
+        output_single({"id": 1, "[b]rows": [{"[i]col": "x"}]}, "table")
+        out = capsys.readouterr().out
+        assert "[b]rows" in out
+        assert "[i]col" in out
+
+    def test_empty_nested_field_name_survives(self, capsys):
+        output_single({"[b]rows": []}, "table")
+        assert "[b]rows" in capsys.readouterr().out

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -14,6 +14,7 @@ from tl_cli.output.formatter import (
     _output_markdown,
     _sanitize_for_json,
     detect_format,
+    output_single,
 )
 
 
@@ -509,3 +510,21 @@ class TestServerWarnings:
         output_pricing_estimate(data, "table")
         err = " ".join(capsys.readouterr().err.split())
         assert "Warning:" in err
+
+
+class TestDetailValuesAreNotMarkup:
+    """Free-text values are data, not Rich markup.
+
+    A profile memory or a note holding a square-bracketed token is ordinary text;
+    rendering it as a tag either eats the word or aborts the command.
+    """
+
+    def test_bracketed_token_survives_and_does_not_raise(self, capsys):
+        output_single({"note": "Avoids [crypto] and [/finance] verticals."}, "table")
+        out = capsys.readouterr().out
+        assert "[crypto]" in out
+        assert "[/finance]" in out
+
+    def test_bold_looking_value_is_not_styled_away(self, capsys):
+        output_single({"note": "[bold]not a tag[/bold]"}, "table")
+        assert "[bold]not a tag[/bold]" in capsys.readouterr().out


### PR DESCRIPTION
Client half of the profile-memory utilities. Depends on
ThoughtLeaders-io/thoughtleaders#4308 — the commands only return real data once
`GET/POST /api/cli/v1/memory` is deployed.

## Commands

```bash
tl memory show                                 # GET /memory
tl memory show --profile-id 8871               # another profile (full-access only)
tl memory add "Stopped doing finance ads."     # POST {"fact": ...}  — server merges
tl memory set --from-file ./memory.txt         # POST {"memory": ...} — wholesale
```

`add` is the ordinary verb: the server folds the fact into the existing summary,
keeping what's still true and replacing only what the fact contradicts. `set` is the
repair hatch for when a merge has damaged a memory and is deliberately not
length-guarded. Both always write the caller's own profile regardless of permissions.
All three are free.

Also documents them in `skills/tl/SKILL.md`. That part isn't polish — it's what makes
these *the standard method for updating user data*, which was the actual ask. The
skill loads into every session, so a command missing from it is one no agent will
call.

## Testing

`tests/test_memory.py`, 8 cases, following `tests/test_profiles.py` (CliRunner + a
fake client recording calls). Every case asserts on the recorded request, not just
the exit code, so none can pass for the wrong reason. Local rejections (empty fact,
missing `--from-file` target, both-or-neither source) are verified to make no request
at all.

Full suite: **471 passed, 1 failed** — the failure is pre-existing on `main` and
unrelated (`test_setup_marker_respect.py::...::test_marked_identical_copy_is_not_deleted`
asserts on Rich-rendered stderr that a Windows console mangles). Baseline on
`origin/main` is 463 passed / same 1 failed, so this adds 8 and regresses nothing.

Note for reviewers: these are in `tests/` (mocked), not `tests_cli/`. That suite is
live and read-only by contract — `tl memory add`/`set` are POST-backed writes, and
running them there would mutate a real profile's memory against the live API.

Spec and plan live in the server repo under
`docs/superpowers/{specs,plans}/2026-08-03-profile-memory-cli-utilities*`.