### PR TITLE
Add --organization-id flag to comment-list and comment-add

### DIFF
--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -227,7 +227,16 @@ tl <entity> comment-edit <comment-id> "msg"  # Edit own comment (author or super
 
 **Credit costs are server-authoritative — run `tl describe` (overview) or `tl describe show <resource>` (one resource) to see the current rates and multipliers for every endpoint. Do not memorise rate values — they change.**
 
-### Updating records
+### Commenting as another organization (superusers)
+
+`--organization-id` takes a **numeric org ID only** — never guess it from an org name. Comments are an org's private notes, so posting (or reading) under the wrong org is a real data leak. When the user names the target org instead of giving an ID:
+
+1. Resolve the name first, e.g. `tl db pg "SELECT id, name, created_at FROM thoughtleaders_organization WHERE name ILIKE '%<name>%'"`.
+2. **Exactly one match** → use its ID, and state which org you resolved to ("posting as <name>, org <id>") so the user can catch a wrong pick.
+3. **Multiple matches (org names are NOT unique)** → STOP and ask the user which one. Never pick silently, not even by "most recently active" or "biggest". Present the candidates with enough context to tell them apart — for each: org ID, plan, member names/emails (`thoughtleaders_profile` joined to `auth_user` via `organization_id`), created date, and recent activity (e.g. deals/sponsorships reachable via the org's profiles) when the users alone don't disambiguate.
+4. **Zero matches** → report it and ask; don't fuzzy-match to something else.
+
+Omitting the flag always posts to your own org — when the user doesn't name an org, don't pass the flag at all.
 
 ```bash
 tl sponsorships update <id> '<json>'   # Edit a sponsorship (adlink)

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -221,7 +221,8 @@ tl reports link <id> --source <id> --entity <e> [--type include|exclude] [--sour
 tl reports unlink <id> --source <id> [--entity <e>] [--type include|exclude]  # Remove report links (all from that source unless narrowed)
 tl <entity> comment-list <id>          # List comments on a sponsorship/channel/brand/upload
 tl <entity> comment-add <id> "msg"     # Add a comment
-tl <entity> comment-edit <comment-id> "msg"  # Edit own comment (author or superuser)
+tl <entity> comment-list/comment-add ... --organization-id <id>  # Superusers: read/write another org's comments (defaults to your own org)
+tl <entity> comment-edit <comment-id> "msg"  # Edit own comment (author or superuser); always your own org's comments
 ```
 
 **Credit costs are server-authoritative — run `tl describe` (overview) or `tl describe show <resource>` (one resource) to see the current rates and multipliers for every endpoint. Do not memorise rate values — they change.**

--- a/src/tl_cli/client/http.py
+++ b/src/tl_cli/client/http.py
@@ -26,8 +26,8 @@ class TLClient:
     def get(self, path: str, params: dict | None = None, timeout: float | None = None) -> dict:
         return self._request("GET", path, params=params, timeout=timeout)
 
-    def post(self, path: str, json_body: dict | None = None) -> dict:
-        return self._request("POST", path, json_body=json_body)
+    def post(self, path: str, json_body: dict | None = None, params: dict | None = None) -> dict:
+        return self._request("POST", path, json_body=json_body, params=params)
 
     def patch(self, path: str, json_body: dict | None = None) -> dict:
         return self._request("PATCH", path, json_body=json_body)

--- a/src/tl_cli/commands/_comments_common.py
+++ b/src/tl_cli/commands/_comments_common.py
@@ -17,12 +17,24 @@ from tl_cli.output.formatter import detect_format, output, output_single
 
 COLUMNS = ["comment_id", "author", "text", "created_at"]
 
+_ORG_ID_HELP = "Read/write comments as another organization (superuser only; defaults to your own org)"
 
-def list_comments(entity_type: str, entity_id: str, json_output: bool, toon_output: bool) -> None:
+
+def _org_params(organization_id: int | None) -> dict | None:
+    return {"organization_id": organization_id} if organization_id is not None else None
+
+
+def list_comments(
+    entity_type: str,
+    entity_id: str,
+    json_output: bool,
+    toon_output: bool,
+    organization_id: int | None = None,
+) -> None:
     fmt = detect_format(json_output, False, False, toon_output)
     client = get_client()
     try:
-        data = client.get(f"/{entity_type}/{entity_id}/comments")
+        data = client.get(f"/{entity_type}/{entity_id}/comments", params=_org_params(organization_id))
         for r in data.get("results", []):
             r["comment_id"] = r.pop("id", None)
         output(
@@ -37,11 +49,22 @@ def list_comments(entity_type: str, entity_id: str, json_output: bool, toon_outp
         client.close()
 
 
-def add_comment(entity_type: str, entity_id: str, message: str, json_output: bool, toon_output: bool) -> None:
+def add_comment(
+    entity_type: str,
+    entity_id: str,
+    message: str,
+    json_output: bool,
+    toon_output: bool,
+    organization_id: int | None = None,
+) -> None:
     fmt = detect_format(json_output, False, False, toon_output)
     client = get_client()
     try:
-        data = client.post(f"/{entity_type}/{entity_id}/comments", json_body={"text": message})
+        data = client.post(
+            f"/{entity_type}/{entity_id}/comments",
+            json_body={"text": message},
+            params=_org_params(organization_id),
+        )
         for r in data.get("results", []):
             r["comment_id"] = r.pop("id", None)
         output_single(data, fmt)
@@ -80,19 +103,21 @@ def register_comment_commands(app: typer.Typer, entity_type: str, entity_label: 
     @app.command("comment-list", help=f"List comments on a {entity_label} (free, no credits).")
     def comment_list(
         entity_id: str = typer.Argument(..., help=f"{entity_label.capitalize()} ID"),
+        organization_id: int | None = typer.Option(None, "--organization-id", help=_ORG_ID_HELP),
         json_output: bool = typer.Option(False, "--json", help="JSON output"),
         toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
     ) -> None:
-        list_comments(entity_type, entity_id, json_output, toon_output)
+        list_comments(entity_type, entity_id, json_output, toon_output, organization_id)
 
     @app.command("comment-add", help=f"Add a comment to a {entity_label} (free, no credits).")
     def comment_add(
         entity_id: str = typer.Argument(..., help=f"{entity_label.capitalize()} ID"),
         message: str = typer.Argument(..., help="Comment text"),
+        organization_id: int | None = typer.Option(None, "--organization-id", help=_ORG_ID_HELP),
         json_output: bool = typer.Option(False, "--json", help="JSON output"),
         toon_output: bool = typer.Option(False, "--toon", help="TOON output (token-efficient for LLMs)"),
     ) -> None:
-        add_comment(entity_type, entity_id, message, json_output, toon_output)
+        add_comment(entity_type, entity_id, message, json_output, toon_output, organization_id)
 
     @app.command("comment-edit")
     def comment_edit(

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,70 @@
+"""Tests for the shared comment subcommands (comment-list / comment-add).
+
+Asserts the `--organization-id` flag wiring: when passed, it is sent as the
+`organization_id` query param on both list (GET) and add (POST); when omitted,
+no params are sent at all.
+"""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from tl_cli.commands.channels import app as channels_app
+
+runner = CliRunner()
+
+
+class _FakeClient:
+    """Records calls and returns a fixed comments payload."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def get(self, path: str, params: dict | None = None) -> dict:
+        self.calls.append(("GET", path, params))
+        return self._payload()
+
+    def post(self, path: str, json_body: dict | None = None, params: dict | None = None) -> dict:
+        self.calls.append(("POST", path, params))
+        return self._payload()
+
+    @staticmethod
+    def _payload() -> dict:
+        return {
+            "results": [
+                {"id": 7, "author": "Ada L", "text": "note", "created_at": "2026-08-05T10:00:00"},
+            ],
+            "total": 1,
+            "_breadcrumbs": [],
+        }
+
+    def close(self) -> None:
+        pass
+
+
+def _run(args: list[str]) -> _FakeClient:
+    fake = _FakeClient()
+    with patch("tl_cli.commands._comments_common.get_client", return_value=fake):
+        result = runner.invoke(channels_app, args)
+    assert result.exit_code == 0, result.output
+    return fake
+
+
+class TestCommentList:
+    def test_no_org_flag_sends_no_params(self) -> None:
+        fake = _run(["comment-list", "123", "--json"])
+        assert fake.calls == [("GET", "/channel/123/comments", None)]
+
+    def test_org_flag_sent_as_query_param(self) -> None:
+        fake = _run(["comment-list", "123", "--organization-id", "456", "--json"])
+        assert fake.calls == [("GET", "/channel/123/comments", {"organization_id": 456})]
+
+
+class TestCommentAdd:
+    def test_no_org_flag_sends_no_params(self) -> None:
+        fake = _run(["comment-add", "123", "hello", "--json"])
+        assert fake.calls == [("POST", "/channel/123/comments", None)]
+
+    def test_org_flag_sent_as_query_param(self) -> None:
+        fake = _run(["comment-add", "123", "hello", "--organization-id", "456", "--json"])
+        assert fake.calls == [("POST", "/channel/123/comments", {"organization_id": 456})]


### PR DESCRIPTION
## Summary
- Adds an optional `--organization-id` flag to the `comment-list` and `comment-add` subcommands on all four entities (sponsorships, channels, brands, uploads). When passed, it is sent as the `organization_id` query param, letting superusers read and write another organization's comments — the same capability the browser extension's org picker already uses. Non-superusers targeting a foreign org get the server's 403; omitting the flag sends no param and defaults to the caller's own org.
- `TLClient.post()` now accepts query params (backward-compatible, defaults to `None`).
- `comment-edit` is unchanged: the edit endpoint only operates on the caller's own org, so there is no flag to expose there.
- The flag accepts a **numeric org ID only** — org names are never sent or matched. The `tl` skill gains a "Commenting as another organization" section instructing agents to resolve a user-named org via a DB lookup first, echo the resolved org back, and **ask the user which org is meant whenever more than one shares the name** (presenting ID, plan, members, created date, and deal activity), since org names are not unique and comments are an org's private notes.

## Test plan
- New `tests/test_comments.py` asserts the flag is forwarded as the query param on both GET and POST, and that omitting it sends no params at all.
- Full suite: 468 passed; CI green on py3.12–3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)