### PR TITLE
Show Industry Weekly membership in tl whoami

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thoughtleaders-cli"
-version = "0.9.6"
+version = "0.9.7"
 description = "ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence"
 readme = "README.md"
 license = "MIT"

--- a/src/tl_cli/commands/whoami.py
+++ b/src/tl_cli/commands/whoami.py
@@ -17,6 +17,18 @@ from tl_cli.output.formatter import detect_format
 app = typer.Typer(cls=AlphaSortedTyperGroup, help="Show current user, profile, org, and brands (free)")
 
 
+def _newsletter_subscribed(data: dict) -> bool | None:
+    """Industry Weekly membership, or None when the response doesn't say.
+
+    The field is absent whenever membership can't be determined, so None means
+    unknown — callers must not render it as a "no".
+    """
+    newsletter = data.get("newsletter")
+    if not isinstance(newsletter, dict) or "subscribed" not in newsletter:
+        return None
+    return bool(newsletter["subscribed"])
+
+
 def _render_whoami(data: dict) -> None:
     """Rich-formatted whoami output."""
     console = Console()
@@ -53,6 +65,16 @@ def _render_whoami(data: dict) -> None:
     lines.append("\n")
     lines.append("Joined:  ", style="dim")
     lines.append(user.get("date_joined", "")[:10])
+    # Unknown membership prints no row at all, rather than a "no" the reader
+    # would take as fact.
+    subscribed = _newsletter_subscribed(data)
+    if subscribed is not None:
+        lines.append("\n")
+        lines.append("Weekly:  ", style="dim")
+        lines.append(
+            "subscribed" if subscribed else "not subscribed",
+            style="green" if subscribed else "yellow",
+        )
 
     console.print(Panel(lines, title=title, border_style="cyan"))
 
@@ -141,6 +163,9 @@ def _render_whoami_md(data: dict) -> None:
         print(f"- **Flags:** {', '.join(flags)}")
     print(f"- **Paid:** {'yes' if profile.get('is_paid') else 'no'}")
     print(f"- **Joined:** {user.get('date_joined', '')[:10]}")
+    subscribed = _newsletter_subscribed(data)
+    if subscribed is not None:
+        print(f"- **Industry Weekly:** {'subscribed' if subscribed else 'not subscribed'}")
 
     print(f"\n## Organization: {org.get('name', '')}\n")
     plan = org.get("plan")

--- a/tests/test_whoami_newsletter.py
+++ b/tests/test_whoami_newsletter.py
@@ -1,0 +1,77 @@
+"""Tests for the Industry Weekly row in `tl whoami`.
+
+Membership is absent from the response whenever it can't be determined, so the
+renderers must treat that as unknown and print nothing — never a "not
+subscribed" the reader would take as fact.
+"""
+
+import io
+from contextlib import redirect_stdout
+
+from tl_cli.commands.whoami import _newsletter_subscribed, _render_whoami, _render_whoami_md
+
+
+def _payload(newsletter=None) -> dict:
+    data = {
+        "user": {"email": "a@x.test", "first_name": "A", "last_name": "B", "date_joined": "2022-05-08T10:12:00+00:00"},
+        "profile": {"flags": ["advertiser"], "is_paid": True, "persona": None},
+        "organization": {"name": "Org", "plan": "Pro"},
+        "associated_profiles": [],
+        "brands": [],
+    }
+    if newsletter is not None:
+        data["newsletter"] = newsletter
+    return data
+
+
+def _render(fn, data: dict) -> str:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        fn(data)
+    return buffer.getvalue()
+
+
+class TestNewsletterSubscribed:
+    def test_true_when_subscribed(self):
+        assert _newsletter_subscribed(_payload({"subscribed": True})) is True
+
+    def test_false_when_not_subscribed(self):
+        assert _newsletter_subscribed(_payload({"subscribed": False})) is False
+
+    def test_none_when_key_absent(self):
+        assert _newsletter_subscribed(_payload()) is None
+
+    def test_none_when_block_is_missing_the_field(self):
+        assert _newsletter_subscribed(_payload({})) is None
+
+    def test_none_when_block_is_not_an_object(self):
+        assert _newsletter_subscribed(_payload("yes")) is None
+
+
+class TestRenderWhoami:
+    def test_subscribed_is_shown(self):
+        assert "subscribed" in _render(_render_whoami, _payload({"subscribed": True}))
+
+    def test_non_subscriber_is_shown_as_not_subscribed(self):
+        assert "not subscribed" in _render(_render_whoami, _payload({"subscribed": False}))
+
+    def test_unknown_prints_no_newsletter_row(self):
+        out = _render(_render_whoami, _payload())
+        assert "subscribed" not in out
+        assert "Weekly" not in out
+
+    def test_unrelated_rows_still_render(self):
+        out = _render(_render_whoami, _payload({"subscribed": True}))
+        assert "advertiser" in out
+
+
+class TestRenderWhoamiMd:
+    def test_subscribed_is_shown(self):
+        assert "**Industry Weekly:** subscribed" in _render(_render_whoami_md, _payload({"subscribed": True}))
+
+    def test_non_subscriber_is_shown_as_not_subscribed(self):
+        out = _render(_render_whoami_md, _payload({"subscribed": False}))
+        assert "**Industry Weekly:** not subscribed" in out
+
+    def test_unknown_prints_no_newsletter_row(self):
+        assert "Industry Weekly" not in _render(_render_whoami_md, _payload())


### PR DESCRIPTION
Membership arrived in the whoami response, but `tl whoami` never displayed it.

## What changed

- New `Weekly:` row in the default table output, and `- **Industry Weekly:**` in `--md`.
- Shared `_newsletter_subscribed()` helper returning `True` / `False` / `None`.
- Version bumped to 0.9.7.

## Why it was invisible

Both renderers pull a fixed set of keys out of the response (`user`, `profile`, `organization`, `associated_profiles`, `brands`) and discard everything else. `--json` and `--toon` dump the payload verbatim, which is why the field showed up there and nowhere else.

## Unknown is not "no"

Membership is absent from the response whenever it cannot be determined. That is rendered as **no row at all** — printing "not subscribed" would state something the reader would take as fact. Pinned by tests in both renderers.

The label differs by format on purpose: the table labels are hand-padded to a 9-character column (`Flags:`, `Paid:`, `Joined:`), so it reads `Weekly:`; markdown has no such constraint and spells out `Industry Weekly`.

## Rendered

```
╭──────── "Arik Aviv" <arik@thoughtleaders.io> ────────╮
│ Flags:   advertiser                                  │
│ Paid:    yes                                         │
│ Joined:  2022-05-08                                  │
│ Weekly:  subscribed                                  │
╰──────────────────────────────────────────────────────╯
```

## Tests

New `tests/test_whoami_newsletter.py` — 12 tests: helper returns true/false/none (absent key, missing field, non-object), and each renderer for subscribed / not-subscribed / unknown.

Full suite: **499 passed** (487 existing + 12 new).

Note for anyone running the suite locally: 15 unrelated tests in `test_error_hints.py`, `test_output.py` and `test_setup_marker_respect.py` fail when the environment forces colour, because they assert on plain substrings that ANSI codes then split. Run with `NO_COLOR=1 TERM=dumb` and they pass. Not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)