### PR TITLE
Bring __version__ and the plugin manifest up to 0.9.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tl-cli",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "ThoughtLeaders CLI — query sponsorship deals, channels, brands, uploads, and intelligence from the terminal",
   "author": {
     "name": "ThoughtLeaders",

--- a/src/tl_cli/__init__.py
+++ b/src/tl_cli/__init__.py
@@ -1,3 +1,3 @@
 """ThoughtLeaders CLI — query sponsorship data, channels, brands, and intelligence."""
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"


### PR DESCRIPTION
The version string lives in three files that must move together. The 0.9.7 bump in #84 only landed in `pyproject.toml`, leaving main inconsistent:

| File | Before | After |
| --- | --- | --- |
| `pyproject.toml` | 0.9.7 | 0.9.7 |
| `src/tl_cli/__init__.py` | **0.9.6** | 0.9.7 |
| `.claude-plugin/plugin.json` | **0.9.6** | 0.9.7 |

`tl --version` reads `__version__`, so it reported 0.9.6 on a 0.9.7 build.

Full suite: 499 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)