### PR TITLE
List the people who can grant a seat, when there are several

### DIFF
--- a/src/tl_cli/client/errors.py
+++ b/src/tl_cli/client/errors.py
@@ -65,7 +65,9 @@ def handle_api_error(error: ApiError) -> None:
         # frees up. Collapsing that to a flat "rate limited" line drops the only
         # thing that tells the user whether to wait, buy credits, or ask for a
         # seat. An edge/WAF 429 carries no detail and keeps the generic wording.
-        if error.detail:
+        if _print_no_seat(error):
+            pass
+        elif error.detail:
             err.print(f"[yellow]{error.detail}[/yellow]")
         else:
             err.print("[yellow]Rate limited.[/yellow] Please wait and try again.")
@@ -90,3 +92,38 @@ def handle_api_error(error: ApiError) -> None:
             err.print(f"[red]Error ({error.status_code}):[/red] {detail}")
         _print_debug(error)
         sys.exit(1)
+
+
+def _print_no_seat(error: ApiError) -> bool:
+    """Render the seatless refusal as its own thing, or return False.
+
+    The server already composes a complete sentence for this case and the 429
+    branch above would print it — but when several people can grant the seat
+    they arrive as a comma-run inside one long line, which is the least legible
+    shape for the only part the reader has to act on. The refusal also carries
+    them structurally (`_billing_seat_admins`), so they can be listed instead.
+
+    Everything else about the 429 path is deliberately left alone: the server
+    owns the wording, and this must not become a second place that composes it.
+    """
+    raw = error.raw if isinstance(error.raw, dict) else {}
+    admins = raw.get("_billing_seat_admins")
+    # Only worth taking over when there is actually a list to lay out; a
+    # single-contact or self-serve refusal reads fine as the server's sentence.
+    if not raw.get("_billing_no_seat") or not isinstance(admins, list) or len(admins) < 2:
+        return False
+    err.print(
+        "[yellow]No CLI seat.[/yellow] Your organization is on a paid plan, "
+        "but your user isn't assigned to a seat."
+    )
+    err.print("Ask an owner or admin on your team to assign you one:")
+    for a in admins:
+        if not isinstance(a, dict):
+            continue
+        name = a.get("name") or a.get("email") or "?"
+        role = a.get("role") or ""
+        err.print(f"  · {name} <{a.get('email', '')}>" + (f" [dim]({role})[/dim]" if role else ""))
+    url = raw.get("_billing_seats_url")
+    if url:
+        err.print(f"Seats are managed at: [bold]{url}[/bold]")
+    return True

--- a/tests/test_no_seat_error.py
+++ b/tests/test_no_seat_error.py
@@ -1,0 +1,97 @@
+"""Tests for the seatless 429's multi-contact rendering.
+
+`handle_api_error` prints the server's `detail` verbatim for a 429, which is
+right: the server owns the wording and there must not be a second place that
+composes it. The one exception is the seat refusal when several people can grant
+it — the server has to run their names together inside one sentence, which is
+the least legible shape for the only part the reader has to act on. The refusal
+carries them structurally too, so they get listed.
+
+`tests/test_quota_refusal_message.py` covers the verbatim path this sits on top of.
+"""
+
+import pytest
+
+from tl_cli.client.errors import ApiError, handle_api_error
+
+SEATS_URL = "https://app.thoughtleaders.io/#/settings/profile?tab=organization"
+
+
+def _render(error: ApiError, capsys) -> str:
+    with pytest.raises(SystemExit) as exc:
+        handle_api_error(error)
+    assert exc.value.code == 3
+    return " ".join(capsys.readouterr().err.split())  # undo console wrapping
+
+
+def _no_seat(admins: list[dict[str, str]]) -> ApiError:
+    names = ", ".join(f"{a['name']} ({a['email']})" for a in admins)
+    detail = (
+        "Your organization is on a paid plan, but your user has no CLI seat. "
+        f"Ask {names} to assign you one: {SEATS_URL}"
+    )
+    return ApiError(
+        429,
+        detail,
+        raw={
+            "detail": detail,
+            "_billing_no_seat": True,
+            "_billing_can_manage_seats": False,
+            "_billing_seat_admins": admins,
+            "_billing_seats_url": SEATS_URL,
+        },
+    )
+
+
+class TestSeatlessRefusal:
+    def test_several_contacts_are_listed_rather_than_run_together(self, capsys):
+        out = _render(
+            _no_seat(
+                [
+                    {"name": "Vaibhav Sisinty", "email": "vaibhav@outskill.com", "role": "owner"},
+                    {"name": "Amir Bar", "email": "amir@outskill.com", "role": "admin"},
+                ]
+            ),
+            capsys,
+        )
+        assert "No CLI seat." in out
+        assert "· Vaibhav Sisinty <vaibhav@outskill.com>" in out
+        assert "· Amir Bar <amir@outskill.com>" in out
+        assert SEATS_URL in out
+        # Never the pre-fix wording: nothing is rate limiting them, and waiting
+        # will never unblock them.
+        assert "Rate limited" not in out
+
+    def test_a_single_contact_is_left_to_the_server_sentence(self, capsys):
+        # One name reads fine inline, so this stays on the verbatim path rather
+        # than growing a second renderer for it.
+        out = _render(
+            _no_seat([{"name": "Vaibhav Sisinty", "email": "vaibhav@outskill.com", "role": "owner"}]),
+            capsys,
+        )
+        assert "Ask Vaibhav Sisinty (vaibhav@outskill.com) to assign you one" in out
+        assert "No CLI seat." not in out
+
+    def test_a_self_serve_refusal_is_left_alone(self, capsys):
+        detail = (
+            "Your organization is on a paid plan, but your user has no CLI seat. "
+            f"You are an admin here, so you can assign one to yourself on your team page: {SEATS_URL}"
+        )
+        out = _render(
+            ApiError(
+                429,
+                detail,
+                raw={
+                    "detail": detail,
+                    "_billing_no_seat": True,
+                    "_billing_can_manage_seats": True,
+                    "_billing_seat_admins": [],
+                },
+            ),
+            capsys,
+        )
+        assert "you can assign one to yourself" in out
+        assert "Ask an owner or admin" not in out
+
+    def test_a_bare_429_is_untouched(self, capsys):
+        assert "Rate limited." in _render(ApiError(429, "", raw=None), capsys)


### PR DESCRIPTION
CLI half of a three-repo fix. Pairs with [thoughtleaders#4393](https://github.com/ThoughtLeaders-io/thoughtleaders/pull/4393) (server) and [tl-chrome-extension#176](https://github.com/ThoughtLeaders-io/tl-chrome-extension/pull/176).

## Scope changed on rebase — please read

This branch originally fixed the 429 handler, which collapsed every 429 to `"Rate limited. Please wait and try again."` and discarded `error.detail`. **Ivan fixed that on main first** ([dfe3cf3](https://github.com/ThoughtLeaders-io/thoughtleaders-cli/commit/dfe3cf3)), and fixed it the better way — print the server's `detail` verbatim, so the wording lives in exactly one place.

So most of this branch is gone. What was left duplicated his change, and duplicating message composition across server and client is the thing the server PR is deliberately avoiding.

## What survives

One narrow case: **when several owners/admins can grant the seat.** The server has to run their names together inside a single sentence —

> Ask Vaibhav Sisinty (vaibhav@outskill.com), Amir Bar (amir@outskill.com) to assign you one: …

— which is the least legible shape for the only part of the message the reader has to act on. The refusal also carries them structurally (`_billing_seat_admins`), so they get laid out:

```
No CLI seat. Your organization is on a paid plan, but your user isn't assigned to a seat.
Ask an owner or admin on your team to assign you one:
  · Vaibhav Sisinty <vaibhav@outskill.com> (owner)
  · Amir Bar <amir@outskill.com> (admin)
Seats are managed at: https://app.thoughtleaders.io/#/settings/profile?tab=organization
```

Deliberately narrow: a **single** contact and a **self-serve** (admin) refusal both read fine as the server's own sentence and stay on the verbatim path. This must not become a second place that composes the message.

Degrades to nothing against an older server: no `_billing_seat_admins` key, no match, every 429 keeps Ivan's behaviour.

**If you'd rather not have the special case at all, this PR is fine to close** — the server sentence is complete on its own, and Ivan's change already delivers it. The only thing lost is the list layout.

## Tests

`tests/test_no_seat_error.py` — multi-contact listing, single contact left on the verbatim path, self-serve left alone, bare 429 untouched. Passes alongside `test_quota_refusal_message.py` (Ivan's) and `test_error_hints.py`: 13 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)