### PR TITLE
Add `tl setup windows` to run the CLI under Smart App Control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,31 @@ jobs:
         # tests/ mock the HTTP client (CliRunner + fake get_client), so there
         # is no network, no API key, and no credit spend.
         run: uv run --python ${{ matrix.python-version }} --with pytest pytest tests/ -v
+
+  windows-launcher:
+    name: Windows launcher (tl setup windows)
+    # `tl setup windows` writes a tl.cmd that runs the CLI through the signed
+    # python.exe, so the unsigned pipx stub can't be blocked by Smart App
+    # Control. This job proves the wrapper is written and actually launches the
+    # CLI. NOTE: GitHub runners don't have SAC in enforcement, so this verifies
+    # the mechanism, not the block itself — real SAC validation needs a SAC/WDAC
+    # machine. Hermetic: a uv project install is a dev install, so the CLI's
+    # auto-updater no-ops (no network).
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Sync locked dependencies
+        run: uv sync --frozen
+      - name: Install the launcher wrapper
+        run: uv run tl setup windows
+      - name: Wrapper exists and launches the CLI through python
+        shell: pwsh
+        run: |
+          $cmd = "$env:LOCALAPPDATA\Programs\tl-cli\tl.cmd"
+          if (-not (Test-Path $cmd)) { throw "wrapper not written at $cmd" }
+          Get-Content $cmd
+          & $cmd --version
+          if ($LASTEXITCODE -ne 0) { throw "wrapper failed to launch the CLI (exit $LASTEXITCODE)" }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ uv tool install thoughtleaders-cli
 pip install thoughtleaders-cli
 ```
 
+#### Windows with Smart App Control / WDAC
+
+The pipx/uv install above creates an **unsigned** launcher stub that Windows
+Smart App Control (and enforced WDAC policies) block — `tl` fails to start with
+a Code Integrity error. Fix it with:
+
+```powershell
+tl setup windows
+```
+
+That drops a small `tl.cmd` on your `PATH` (ahead of the blocked stub) which
+launches the CLI through the already-signed `python.exe`, so it runs cleanly
+under SAC. If `tl` is *already* blocked and won't start, bootstrap it through
+the signed interpreter directly, then reopen your terminal:
+
+```powershell
+& "$env:USERPROFILE\pipx\venvs\thoughtleaders-cli\Scripts\python.exe" -m tl_cli setup windows
+```
+
 Then set up:
 ```bash
 tl auth login          # authenticate with ThoughtLeaders (OAuth2 browser flow, device code, or API key)

--- a/src/tl_cli/__main__.py
+++ b/src/tl_cli/__main__.py
@@ -1,0 +1,13 @@
+"""Module entry point for the CLI.
+
+Enables `python -m tl_cli` and serves as the single entry script for the
+PyInstaller-frozen standalone build (see packaging/tl.spec). Invoking the CLI
+through the signed `python.exe` / signed frozen exe is what keeps it runnable
+under Windows Smart App Control, which blocks the unsigned launcher stub that
+pipx/uv generate per install.
+"""
+
+from tl_cli.main import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/tl_cli/commands/setup.py
+++ b/src/tl_cli/commands/setup.py
@@ -756,3 +756,74 @@ def setup_codex(
         json_output=json_output,
         toon_output=toon_output,
     )
+
+
+def _prepend_user_path(new_dir: str) -> bool:
+    """Prepend ``new_dir`` to the persistent per-user PATH.
+
+    Writes HKCU\\Environment and broadcasts the change so new processes pick it
+    up without a sign-out. Returns True if PATH was changed, False if new_dir
+    was already present. Windows-only.
+    """
+    import ctypes
+    import winreg
+
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment", 0, winreg.KEY_READ | winreg.KEY_WRITE) as key:
+        try:
+            current, _ = winreg.QueryValueEx(key, "Path")
+        except FileNotFoundError:
+            current = ""
+        parts = [p for p in current.split(os.pathsep) if p]
+        target = os.path.normcase(os.path.normpath(new_dir))
+        if any(os.path.normcase(os.path.normpath(p)) == target for p in parts):
+            return False
+        updated = os.pathsep.join([new_dir, *parts]) if parts else new_dir
+        winreg.SetValueEx(key, "Path", 0, winreg.REG_EXPAND_SZ, updated)
+
+    # Tell running shells the environment changed (best-effort).
+    ctypes.windll.user32.SendMessageTimeoutW(0xFFFF, 0x1A, 0, "Environment", 0x2, 5000, None)
+    return True
+
+
+@app.command("windows")
+def setup_windows(
+    force: bool = typer.Option(False, "--force", help="Overwrite an existing tl.cmd wrapper"),
+) -> None:
+    """Make `tl` runnable under Windows Smart App Control (Windows only).
+
+    pipx/uv expose `tl` through an *unsigned* launcher stub that Smart App
+    Control (and enforced WDAC policies) block. This writes a small `tl.cmd`
+    that runs the CLI through the already-signed `python.exe` instead, and
+    puts it ahead of the blocked stub on your PATH.
+
+    Run once. On a machine where `tl` is already blocked, bootstrap it with
+    the venv's signed python directly:
+
+        <pipx-venv>\\Scripts\\python.exe -m tl_cli setup windows
+
+    Examples:
+        tl setup windows
+    """
+    if sys.platform != "win32":
+        console.print("[yellow]`tl setup windows` only applies on Windows — nothing to do here.[/yellow]")
+        return
+
+    python_exe = Path(sys.executable)
+    wrapper_dir = Path(os.environ.get("LOCALAPPDATA", Path.home())) / "Programs" / "tl-cli"
+    wrapper = wrapper_dir / "tl.cmd"
+
+    if wrapper.exists() and not force:
+        console.print(f"[yellow]Wrapper already exists:[/yellow] {wrapper}\nRe-run with --force to regenerate it.")
+        return
+
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    # Absolute path to the signed interpreter bypasses PATH so the launch can't
+    # resolve back to the blocked stub. %* forwards all arguments unchanged.
+    wrapper.write_text(f'@echo off\r\n"{python_exe}" -m tl_cli %*\r\n', encoding="ascii", newline="")
+
+    console.print(f"[green]✓[/green] Wrote signed-launcher wrapper: {wrapper}")
+    if _prepend_user_path(str(wrapper_dir)):
+        console.print(f"[green]✓[/green] Added to your user PATH (ahead of the blocked stub): {wrapper_dir}")
+    else:
+        console.print(f"[dim]Already on your user PATH: {wrapper_dir}[/dim]")
+    console.print("[dim]Open a new terminal, then run:[/dim] tl whoami")


### PR DESCRIPTION
## Problem

On Windows machines with **Smart App Control** (or an enforced WDAC policy), `tl` fails to start with a Code Integrity error. pipx/uv expose `tl` through an **unsigned** launcher stub (a distlib PE with the entry-point payload appended, new hash every release), and SAC blocks unsigned executables. `python.exe` itself is validly signed and runs fine — only the stub is refused.

This is rare (SAC only arms on clean Win11 installs and is a per-machine outlier), but any future Windows user on such a machine hits it.

## Fix

`tl setup windows` writes a small `tl.cmd` that launches the CLI through the already-signed `python.exe` (`-m tl_cli`), and puts it ahead of the blocked stub on the user PATH. It rides PSF's signed+reputable interpreter, so SAC is satisfied — **nothing to sign, no cert, no cost.**

```powershell
tl setup windows          # once it's not blocked
# or bootstrap through the signed python if the stub is already blocked:
& "$env:USERPROFILE\pipx\venvs\thoughtleaders-cli\Scripts\python.exe" -m tl_cli setup windows
```

## Changes

- `src/tl_cli/commands/setup.py` — `tl setup windows` command + `_prepend_user_path()` (writes `HKCU\Environment`, broadcasts `WM_SETTINGCHANGE`)
- `src/tl_cli/__main__.py` *(new)* — enables `python -m tl_cli` (wrapper target + bootstrap)
- `README.md` — Windows/SAC install note
- `.github/workflows/ci.yml` — `windows-latest` job verifying the wrapper is written and launches the CLI (mechanism only; runners have no SAC enforcement)

## Testing

- CI proves the wrapper mechanism on `windows-latest`.
- Real SAC end-to-end can only be validated on a SAC/WDAC-enforced machine — install the branch there and run the bootstrap above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)