### PR TITLE
Drop the publication concept from the skills' data references

### DIFF
--- a/skills/tl-save-report/references/intelligence_filterset_schema.json
+++ b/skills/tl-save-report/references/intelligence_filterset_schema.json
@@ -362,18 +362,6 @@
       "uniqueItems": true,
       "description": "Article IDs to exclude (composite `<channel_id>:<youtube_id>` form). Pairs with a predicate-style FilterSet — useful for 'videos matching X, except these specific ones'.",
       "_tl_django_m2m": "FilterSet.exclude_articles via FiltersetExcludeArticles"
-    },
-
-    "networks": {
-      "type": ["array", "null"],
-      "items": { "type": "integer", "minimum": 1 },
-      "uniqueItems": true,
-      "_tl_django_m2m": "FilterSet.networks → thoughtleaders.Publication"
-    },
-    "exclude_networks": {
-      "type": ["array", "null"],
-      "items": { "type": "integer", "minimum": 1 },
-      "uniqueItems": true
     }
   },
 

--- a/skills/tl-save-report/references/sponsorship_filterset_schema.json
+++ b/skills/tl-save-report/references/sponsorship_filterset_schema.json
@@ -58,18 +58,6 @@
       "_tl_django_m2m": "FilterSet.exclude_brands via FilterSetExcludeBrand"
     },
 
-    "networks": {
-      "type": ["array", "null"],
-      "items": { "type": "integer", "minimum": 1 },
-      "uniqueItems": true,
-      "_tl_django_m2m": "FilterSet.networks → thoughtleaders.Publication"
-    },
-    "exclude_networks": {
-      "type": ["array", "null"],
-      "items": { "type": "integer", "minimum": 1 },
-      "uniqueItems": true
-    },
-
     "start_date": {
       "type": ["string", "null"],
       "format": "date",

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -88,11 +88,11 @@ Other key concepts:
 - **Adspots** — types of ads a channel is willing to publish (e.g. mention, dedicated video, product placement). Returned by `tl channels show`; each carries price/cost.
 - **Profiles** — actors that own sponsorship records on behalf of either side of a deal. A profile is either buyer-side or seller-side:
   - *Buyer-side (brand) profiles* — represent a sponsoring brand. Each brand profile has an M2M link to at most one `Brand` record (which are the actual advertiser identities). On a sponsorship, `advertiser_profile` is the buyer-side profile, and `advertiser_id` is the buyer-side user who created the record — the advertiser is always the buyer/brand side, never the YouTube creator (the channel hangs off `ad_spot_id`).
-  - *Seller-side (publisher) profiles* — attached to a `Publication`, which in turn owns one or more `Channel` records. A channel's adspots therefore inherit ownership through `channel.publication.profile`.
+  - *Seller-side (publisher) profiles* — represent one or more `Channel` records through the `thoughtleaders_profile_channels` link. Representation is not deal ownership: each adspot names its own seller (`ad_spot.publisher`, a user), so a channel's deals belong to whoever sold them, not to everyone who represents the channel.
   - **How to tell them apart** — three signals on the `thoughtleaders_profile` row, used in this order:
     1. **`persona`** (canonical) — `1=Brand`, `4=Media Agency`, `3=Talent Manager` are buyer-side; `2=Creator`, `5=Creator Service` are seller-side. May be null on legacy rows.
     2. **`is_advertiser` / `is_publisher`** booleans — feature flags; either or both can be true for staff-style profiles, but on normal user profiles they reliably mark side.
-  - Org scoping for sponsorships is profile-mediated: a sponsorship belongs to your org if **either** `advertiser_profile.organization` (brand side) **or** `ad_spot.channel.publication.profile.organization` (publisher side) matches yours.
+  - Org scoping for sponsorships is profile-mediated: a sponsorship belongs to your org if **either** `advertiser_profile.organization` (brand side) **or** the adspot seller's organization — `ad_spot.publisher` → that user's profile → `organization` (publisher side) — matches yours. Representing the channel does not by itself surface its deals; only a `sees_all_deals` link on `thoughtleaders_profile_channels` widens the publisher side to every deal on that channel.
 - **MSN** (Media Selling Network) — the ~12k YouTube channels that have opted in to receive sponsorship offers. A channels is in the MSN group if the `channel.media_selling_network_join_date` field is not null.
 - **MBN** (Media Buying Network) — the brand-side counterpart to MSN: brand profiles that have opted in to receive proposed sponsorships. A profile is in the MBN group if the `profile.media_buying_network_join_date` field is not null.
 - **TPP** (ThoughtLeaders Partner Program, a.k.a. "TL channels") — the ~170 channels TL has the closest working relationship with. A channel is in the TPP group if `channel.is_tpp` is True. **Prefer TPP channels when booking**: they respond fastest, are the easiest to close, and don't need an outreach round-trip — treat them as immediately bookable. TPP is a strict subset of MSN, so the same booking rules (one active mention adspot, etc.) apply.
@@ -521,7 +521,6 @@ If unsure about what information to find where, read the [references/postgresql-
 - `Postgres channel.id` ↔ `ES channel.id` (on article docs) ↔ `Firebolt article_metrics.channel_id` / `channel_metrics.id`
 - `Postgres adlink.article_id` is `<channel_id>:<youtube_id>` — same as ES `_id`. Strip the prefix to get `Firebolt article_metrics.id`.
 - `Postgres brand.id` ↔ ES `sponsored_brand_mentions[]` / `organic_brand_mentions[]`.
-- `publication_id` is **deprecated** — don't use it.
 
 **Snapshots are sparse**, especially for older videos. Don't assume two arbitrary dates have data points. For approximations, prefer `tl snapshots` which already implements the project's interpolation logic; falling back to raw `tl db fb` means you handle gaps yourself.
 

--- a/skills/tl/references/elasticsearch-schema.md
+++ b/skills/tl/references/elasticsearch-schema.md
@@ -59,7 +59,7 @@ Filter with `{"term": {"doc_type": "article"}}`. Coverage percentages are live `
 | `content_type` | keyword | `longform` / `short` / `live` — the complete value set. ~71% of docs; older docs have none (missing ≠ longform). Podcast/RSS docs have no `content_type`. |
 | `content_aspects` | keyword | Flags: `podcast`, `paid_promotion`, `unlisted` — the complete value set. Only ~2.6% of docs carry any. |
 | `hashtags` | keyword | Hashtags from the video description, stored **without the leading `#`** and lowercase (e.g. `marchmadness`); non-Latin tags appear percent-encoded (`%D0%B0…`) (~32%) |
-| `channel` | object | Embedded channel subset: `channel.id`, `channel.content_category`, `channel.format`, `channel.publication_id`, `channel.country`, `channel.language` — no text fields, no metrics. This is where a video's language/country/format/category live (top-level `language`, `country`, `format`, `content_category` exist only on channel docs). |
+| `channel` | object | Embedded channel subset: `channel.id`, `channel.content_category`, `channel.format`, `channel.country`, `channel.language` — no text fields, no metrics. This is where a video's language/country/format/category live (top-level `language`, `country`, `format`, `content_category` exist only on channel docs). |
 
 ⚠️ **Channel-doc fields that look like video fields but match 0 video docs:** `total_views`, `engagement`, `duration_live`/`duration_longform`/`duration_shorts`, `language`, `country`, `format`, `content_category`, `face_on_screen`. They live on channel docs (see below); on video docs use the embedded `channel.*` subset where available.
 
@@ -283,5 +283,4 @@ The `transcript` field's `_source` is **YouTube timed-text caption XML**, not pl
 - `sponsored_brand_mentions` and `organic_brand_mentions` are keyword arrays — use `term` queries.
 - For brand mention details (position, snippet, detection_tool), the data is in the `brand_mentions` nested field.
 - **Stored-only fields** — retrievable in `_source` but invisible to `exists`/`term`/`match` (queries on them silently match 0 docs): `url`, `image_url`, `es_index_tag`, `not_sponsored_by`.
-- **`publication_id` is deprecated** — don't use for joins.
 - No write access. The CLI only exposes `_search` against `tl-platform-*`.

--- a/skills/tl/references/postgres-schema.md
+++ b/skills/tl/references/postgres-schema.md
@@ -353,13 +353,18 @@ LIMIT 50 OFFSET 0
 
 ## `thoughtleaders_profile_channels` (Profile ↔ Channel M2M)
 
-| Column | Type |
-|--------|------|
-| `id` | int PK |
-| `profile_id` | int FK |
-| `channel_id` | int FK |
+Which channels a seller-side profile represents. One row per profile/channel pair.
 
-Note: separate from the adspot publisher relationship. Not always in sync.
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | int PK | |
+| `profile_id` | int FK | → `thoughtleaders_profile.id` |
+| `channel_id` | int FK | → `thoughtleaders_channel.id` |
+| `sees_all_deals` | boolean | When true, the profile's organization sees **every** deal on the channel, not only the deals it sold itself. Absent from the sandbox views, so only a full-access context can read it. |
+| `created_where` | varchar | What created the link. NULL on every link that predates the column. |
+| `created_at` | timestamptz | When the link was created. NULL on every link that predates the column — filtering or ordering on it silently drops that whole population. |
+
+⚠️ **Representation is not deal ownership.** A deal's seller is the adspot's own publisher (`thoughtleaders_adspot.publisher_id` → `auth_user`, then `thoughtleaders_profile.user_id` for the org). Joining sponsorships to an org through this table alone over-reports — only a `sees_all_deals = true` row widens the seller side to all of a channel's deals. `publisher_id` is scrubbed from the sandbox adspot view, so the seller-side hop is only queryable from a full-access role.
 
 ## Example queries
 

--- a/src/tl_cli/output/formatter.py
+++ b/src/tl_cli/output/formatter.py
@@ -215,7 +215,7 @@ def _detect_numeric_columns(results: list[dict], columns: list[str]) -> set[str]
                 numeric.discard(col)
     # Don't treat ID-like columns as numeric
     for col in list(numeric):
-        if col.endswith("_id") or col == "id" or "publication" in col:
+        if col.endswith("_id") or col == "id":
             numeric.discard(col)
     # Columns where every sampled value was None/empty aren't meaningfully numeric
     for col in list(numeric):


### PR DESCRIPTION
Publications no longer exist on the platform, so guidance built on them now misleads: a channel query filtering on the old publication field silently matches nothing, and the "networks" report filters are no longer accepted. This removes them from the skill files and filter-set schemas, and corrects how a channel's deals map to an organization — representing a channel is not the same as having sold its deals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)