### PR TITLE
Fix the Shorts definition in the Firebolt reference

### DIFF
--- a/skills/tl/references/firebolt-schema.md
+++ b/skills/tl/references/firebolt-schema.md
@@ -63,7 +63,7 @@ Tracks YouTube video metrics over time. Each row = one scrape of one video on on
 
 **Primary Index: `(channel_id, id)`** — queries MUST filter by `channel_id` first.
 
-**Shorts vs Longform:** `duration < 61` = Short. `duration >= 61` = Longform. In code: `(duration or 100) < 61`. Filter client-side after fetching — `duration` isn't an indexed column so it can't go in WHERE.
+**Shorts vs Longform:** `article_metrics` has no `content_type` column, and `duration` cannot stand in for one — YouTube counts uploads up to 180s as Shorts, so any duration cutoff mislabels them. Take the split from Elasticsearch's `content_type` (`longform` / `short` / `live`), matching on the document id `<channel_id>:<video_id>`.
 
 ### `channel_metrics` — Channel-Level Time-Series
 
@@ -158,7 +158,7 @@ tl db fb "SELECT id, age, view_count FROM article_metrics
           ORDER BY id, age"
 ```
 
-For non-indexed filters (`age IN (30, 180)`, `duration > 60`), pull a slightly wider slice and filter in `jq`/Python.
+For non-indexed filters (`age IN (30, 180)`, `view_count > 1000`), pull a slightly wider slice and filter in `jq`/Python.
 
 ## Common Query Patterns
 
@@ -171,15 +171,17 @@ tl db fb "SELECT id, age, view_count, like_count, comment_count, duration
           ORDER BY age"
 ```
 
-### Get all videos for a channel, then filter client-side to milestone ages and longform
+### Get all videos for a channel, then filter client-side to milestone ages
 
 ```bash
 tl db fb "SELECT id, age, view_count, like_count, comment_count, duration, publication_date
           FROM article_metrics
           WHERE channel_id = 12345
           ORDER BY id, age" --json \
-| jq '.results[] | select(.duration > 60 and (.age == 7 or .age == 30 or .age == 60 or .age == 90 or .age == 180 or .age == 365))'
+| jq '.results[] | select(.age == 7 or .age == 30 or .age == 60 or .age == 90 or .age == 180 or .age == 365)'
 ```
+
+To keep longform only, pull `content_type` from Elasticsearch and intersect on video id — Firebolt cannot tell Shorts apart.
 
 ### Channel subscriber/view growth over time
 


### PR DESCRIPTION
## Summary

The Firebolt reference told every reader of the `tl` skill that `duration < 61` = Short. YouTube has counted uploads of up to **180s** as Shorts since late 2024, so that rule mislabels the entire 61–180s band as longform.

Measured against the live index: **16,652,823** article documents are 61–180s *and* carry `content_type: short`. Only **93** documents are `content_type: short` with `duration > 180`, so the field itself is a clean signal.

## What changed

- **The rule itself.** There is no correct duration cutoff to swap in — `article_metrics` has no `content_type` column (`id, channel_id, channel_format, publication_date, scrape_date, age, view_count, like_count, comment_count, duration`). The reference now says the split must come from Elasticsearch's `content_type`, matched on the document id `<channel_id>:<video_id>`.
- **The worked example** that filtered "longform" client-side with `.duration > 60` in `jq` no longer claims to, and points at ES for the split.
- **The non-indexed-filter example** now uses `view_count > 1000` instead of `duration > 60`, so it stops modelling the wrong pattern.

## Related

The same rule was fixed in the application itself: ThoughtLeaders-io/thoughtleaders#4484 removes every hardcoded 60/61-second cutoff from the Django app in favour of reading `content_type`.

## Test plan

Documentation only — no code paths. Verified by re-reading the rendered section and sweeping the repo for any surviving `duration > 60` / `duration < 61` Shorts rule (none remain).
