### PR TITLE
Hide recommender top-profiles from the public surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ tl channels similar "Tremending girls" min-score:0.85 --limit 5
 tl recommender tags                              # List every tag (free)
 tl recommender tags cooking                      # Search tag names by substring
 tl recommender top-channels "Cooking" msn:yes --limit 50   # Top channels for a tag
-tl recommender top-profiles "Cooking" mbn:yes --limit 30   # Top brand profiles (one brand → potentially multiple profiles)
 tl recommender top-brands "Cooking" --limit 30             # Top brands (deduped from profiles)
 tl recommender channels-with-tag "Cooking"                 # ALL channel IDs loaded on a tag (--min defaults to 0.00001; paged; 1 credit/result)
 tl recommender inspect-channel 12345             # Per-tag breakdown of a channel's vector

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -590,7 +590,7 @@ tl brands find "NordVPN"
 
 `tl channels find` resolves spacing/typo variants on its own ("Deco Destiny" → "DecoDestiny") via YouTube lookups and fuzzy similarity matching — no need to retry with hand-made name variations. A real channel that isn't in the index yet gets queued for analysis automatically (the response says to check back in ~24 hours). A plain "Not found" means even YouTube couldn't find it — treat that as the answer.
 
-**Path 2. Curated tag / category / demographic** — user named a topic that maps cleanly to a recommender tag (`"Cooking"`, `"Tech"`, `"USA share"`, content categories, format hints). Use the recommender — it ranks channels by how strongly they load on a tag, returning ranked similarity scores instead of forcing exact equality. It also returns matching brand profiles alongside the channels — useful when the user wants to know "who buys this kind of inventory."
+**Path 2. Curated tag / category / demographic** — user named a topic that maps cleanly to a recommender tag (`"Cooking"`, `"Tech"`, `"USA share"`, content categories, format hints). Use the recommender — it ranks channels by how strongly they load on a tag, returning ranked similarity scores instead of forcing exact equality. It also ranks brands on the same tags (`top-brands`) — useful when the user wants to know "who buys this kind of inventory."
 
 ```bash
 # Discover the available tag name first (free)
@@ -599,7 +599,7 @@ tl recommender tags cooking
 # Discover tag names containing the substring
 tl recommender tags crypto
 
-# Top channels & profiles loaded on a similarity tag (Intelligence)
+# Top channels & brands loaded on a similarity tag (Intelligence)
 tl recommender top-channels "Cooking" msn:yes --limit 50
 tl recommender top-channels "Tech" --limit 30
 tl recommender top-brands "USA share" mbn:yes --limit 50

--- a/skills/tl/SKILL.md
+++ b/skills/tl/SKILL.md
@@ -124,7 +124,7 @@ When querying sponsorship bookings, filter the rows with `publish_status = 3` (s
 
 Where possible, if searching for a sponsorship match between channels and brands, first search for what do similar brands sponsor / which brands is the channel usually sponsored by. The similarity judgement should be preferably based on similar topics, similar upload frequency, similar channel sizes, and only after all that, on demographics.
 
-Use the `tl channels similar` and `tl brands similar` commands to find channels or brands similar to a particular channel or brand. For category- or topic-driven discovery (e.g. "Find me Cooking channels", "Who scores high on USA share?"), use `tl recommender top-channels "<tag>"` (or `top-brands`/`top-profiles`) against the recommender — that's faster, ranked by category-strength. Run `tl recommender tags` to discover the valid tag names.
+Use the `tl channels similar` and `tl brands similar` commands to find channels or brands similar to a particular channel or brand. For category- or topic-driven discovery (e.g. "Find me Cooking channels", "Who scores high on USA share?"), use `tl recommender top-channels "<tag>"` (or `top-brands`) against the recommender — that's faster, ranked by category-strength. Run `tl recommender tags` to discover the valid tag names.
 
 ## Workflow
 
@@ -205,7 +205,6 @@ tl brands find <query>                 # Resolve a string to {id, name}; matches
 tl brands similar <id-or-name>         # Find similar brands via similarity search
 tl recommender tags [query]            # List similarity tag names — categories, demographics, formats
 tl recommender top-channels "<tag>"    # Top channels loaded on a similarity tag (Intelligence)
-tl recommender top-profiles "<tag>"    # Top brand profiles loaded on a similarity tag
 tl recommender top-brands "<tag>"      # Top brands (deduped from profiles) loaded on a similarity tag
 tl recommender channels-with-tag "<tag>" [--min <v>] # ALL channel IDs scoring >= v on a tag (--min default 0.00001 drops zero-loading channels; paged, enumerates the full set; 1 credit/result; Intelligence)
 tl recommender inspect-channel <ref>   # Show a channel's similarity-profile breakdown (Intelligence)
@@ -611,7 +610,6 @@ tl recommender top-brands "USA share" mbn:yes --limit 50
 | Command | Filters |
 | --- | --- |
 | `top-channels` | `msn:<yes\|no\|all>` (default all), `exclude-for-profile:<id>` |
-| `top-profiles` | `mbn:<yes\|no\|all>` (default all), `exclude-for-channel:<id>` |
 | `top-brands` | `mbn:<yes\|no\|all>` (default all) |
 | `channels-for-profile` | `language:<iso>` (default `en`), `msn:<yes\|no>` (default `no`) |
 | `channels-for-brand` | same as `channels-for-profile` |
@@ -887,7 +885,6 @@ tl channels similar 29834 min-subs:1000000 exclude:477487 --limit 15  # client-s
 tl recommender tags                                            # Full tag list (free)
 tl recommender tags cooking                                    # Search tag names by substring
 tl recommender top-channels "Cooking" msn:yes --limit 50       # Top channels loaded on a tag (25 credits)
-tl recommender top-profiles "Cooking" --limit 30               # Top brand profiles for the tag
 tl recommender top-brands "USA share" mbn:yes --limit 30       # Top brands (deduped) — demographic tag, MBN only
 tl recommender top-channels "Tech" exclude-for-profile:842     # Drop channels already proposed for profile 842
 tl recommender inspect-channel 29834                           # Per-tag breakdown of a channel's vector

--- a/src/tl_cli/commands/recommender.py
+++ b/src/tl_cli/commands/recommender.py
@@ -21,7 +21,7 @@ from tl_cli.client.http import get_client
 from tl_cli.filters import parse_filters
 from tl_cli.output.formatter import detect_format, output, output_single
 
-app = typer.Typer(cls=AlphaSortedTyperGroup, help="Recommender (similarity tags, top-channels/profiles/brands, similarity-profile inspection, profile→channel and channel→brand similarity)")
+app = typer.Typer(cls=AlphaSortedTyperGroup, help="Recommender (similarity tags, top-channels/brands, similarity-profile inspection, profile→channel and channel→brand similarity)")
 
 
 TOP_CHANNEL_COLUMNS = ["value", "channel_id", "channel_name", "slug"]

--- a/src/tl_cli/commands/recommender.py
+++ b/src/tl_cli/commands/recommender.py
@@ -154,7 +154,7 @@ def top_channels_cmd(
     _do_top("channels", tag, args or [], fmt, limit, TOP_CHANNEL_COLUMNS, f"Top channels: {tag}")
 
 
-@app.command("top-profiles")
+@app.command("top-profiles", hidden=True)  # full-access only on the server; not part of the public surface
 def top_profiles_cmd(
     tag: str = typer.Argument(..., help='Similarity tag name (e.g. "Cooking", "Age 18-24"). Run `tl recommender tags` to discover valid names.'),
     args: list[str] = typer.Argument(None, help="Filters (key:value pairs)."),

--- a/uv.lock
+++ b/uv.lock
@@ -422,7 +422,7 @@ wheels = [
 
 [[package]]
 name = "thoughtleaders-cli"
-version = "0.8.1"
+version = "0.9.13"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

- Companion to ThoughtLeaders-io/thoughtleaders#4494. `top-profiles` rows carry brand-owner emails, so the server now restricts it to full-access users and returns 403 to everyone else.
- This PR marks the Typer command `hidden=True` (still callable by superusers), and removes it from README and the `tl` skill (usage line, filter table, discovery guidance, examples).

## Test plan

- `tl recommender --help` no longer lists `top-profiles`; `tl recommender top-profiles "Cooking"` still runs for a full-access user and returns 403 `full_access_required` for anyone else once #4494 is deployed.
- Ruff clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)